### PR TITLE
Refactor Reports

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -47,7 +47,7 @@ UDID="0c1bc52c50016933679b0980ccff3680e5831162"
     - `conversations` - List all SMS and iMessage conversations
     - `list` - List of all backups. alias for -l
     - `manifest` - List all the files contained in the backup (iOS 10+)
-    - `messages` - List all SMS and iMessage messages in a conversation
+    - `messages` - List all SMS and iMessage messages in a conversation. This requires using the `--id` flag to specify a conversation to inspect.
     - `notes` - List all iOS notes
     - `oldnotes` - List all iOS notes (from older unused database)
     - `photolocations` - List all geolocation information for iOS photos (iOS 10+)
@@ -96,18 +96,42 @@ ibackuptool -b $UDID --report manifest --extract BACKUP --filter all
 ibackuptool -b $UDID --report manifest --extract BACKUP --filter CameraRollDomain
 ```
 
+### Reporting formats
+iBackupTool now supports multiple kinds of data export:
+- `table` - Selected data columns in an ascii table
+- `json` - Selected data columns for display (same data as `table`)
+- `csv` - CSV file containing selected columns (same data as `table`)
+
+Additionally, there are more comprehensive export functions that will export ALL the data collected, and keep original formatting and columns:
+- `raw-csv` - Full-data CSV export from each of the tables.
+- `raw`, `raw-json` - Full-data JSON export from each of the tables. This output can be quite large.
+
+### Multiple-Reporting 
+You can also provide a comma separated list of reports to generate. Additionally, there is a special `all` report type which will run all available reports. This is best paired with the `-o` option for saving to disk and the `-f` option for selecting a format such as CSV, or JSON.
+
+```bash
+ibackuptool -b $UDID --report wifi,calls,voicemail
+```
+
+the `-o` option specifies a folder to export reports to:
+```bash
+ibackuptool -b $UDID --report wifi,calls,voicemail -o exported
+```
+
+#### Joined Reports
+Additionally, for the `json` and `raw-json` types, there's a `--join-reports` flag which will merge all of the data into a single JSON file, where the top level object has a key for each report type that is selected.
+
+
 ### Messages Access
 
 ```bash
 # List of all conversations, indexed by ID.
 # Each row starts with an ID number, which is needed for the next step.
-ibackuptool -b $UDID --conversations
 ibackuptool -b $UDID --report conversations
 
 # Now, Fetch the messages with the following command
 # Replace $CONVERSATION_ID with a row ID from `ibackuptool -b $UDID --conversations`
-ibackuptool -b $UDID --messages $CONVERSATION_ID
-ibackuptool -b $UDID --report messages --messages $CONVERSATION_ID
+ibackuptool -b $UDID --report messages --id $CONVERSATION_ID
 ```
 
 ## Need More Data?

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3687 @@
+{
+  "name": "ibackuptool",
+  "version": "3.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "1.0.3"
+      }
+    },
+    "asn1": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+      "dev": true
+    },
+    "assert-plus": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+      "dev": true
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
+    "aws-sign2": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+      "dev": true
+    },
+    "aws4": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "base64-js": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz",
+      "integrity": "sha1-o5mS1yNYSBGYK+XikLtqU9hnAPE="
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "tweetnacl": "0.14.5"
+      }
+    },
+    "big-integer": {
+      "version": "1.6.26",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.26.tgz",
+      "integrity": "sha1-OvFnL6Ytry1eyvrPblqg0l4Cwcg="
+    },
+    "bind-obj-methods": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/bind-obj-methods/-/bind-obj-methods-1.0.0.tgz",
+      "integrity": "sha1-T1l5ysFXk633DkiBYeRj4gnKUJw=",
+      "dev": true
+    },
+    "bluebird": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+      "dev": true
+    },
+    "boom": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+      "dev": true,
+      "requires": {
+        "hoek": "2.16.3"
+      }
+    },
+    "bplist-parser": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.1.1.tgz",
+      "integrity": "sha1-1g1dzCDLptx+HymbNdPh+V2vuuY=",
+      "requires": {
+        "big-integer": "1.6.26"
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "caseless": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+      "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+      "dev": true
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
+      },
+      "dependencies": {
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        }
+      }
+    },
+    "clean-yaml-object": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/clean-yaml-object/-/clean-yaml-object-0.1.0.tgz",
+      "integrity": "sha1-Y/sRDcLOGoTcIfbZM0h20BCui2g=",
+      "dev": true
+    },
+    "cli-table": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
+      "integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
+      "requires": {
+        "colors": "1.0.3"
+      }
+    },
+    "color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "dev": true
+    },
+    "colors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
+    },
+    "combined-stream": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
+    },
+    "commander": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+      "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA=="
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "coveralls": {
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.13.3.tgz",
+      "integrity": "sha512-iiAmn+l1XqRwNLXhW8Rs5qHZRFMYp9ZIPjEOVRpC/c4so6Y/f4/lFi0FfR5B9cCqgyhkJ5cZmbvcVRfP8MHchw==",
+      "dev": true,
+      "requires": {
+        "js-yaml": "3.6.1",
+        "lcov-parse": "0.0.10",
+        "log-driver": "1.2.5",
+        "minimist": "1.2.0",
+        "request": "2.79.0"
+      },
+      "dependencies": {
+        "js-yaml": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
+          "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
+          "dev": true,
+          "requires": {
+            "argparse": "1.0.10",
+            "esprima": "2.7.3"
+          }
+        }
+      }
+    },
+    "cross-spawn": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+      "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "4.1.1",
+        "which": "1.3.0"
+      }
+    },
+    "cryptiles": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+      "dev": true,
+      "requires": {
+        "boom": "2.10.1"
+      }
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
+    },
+    "diff": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+      "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
+      "dev": true
+    },
+    "ecc-jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "jsbn": "0.1.1"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "esprima": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+      "dev": true
+    },
+    "events-to-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/events-to-array/-/events-to-array-1.1.2.tgz",
+      "integrity": "sha1-LUH1Y+H+QA7Uli/hpNXGp1Od9/Y=",
+      "dev": true
+    },
+    "extend": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+      "dev": true
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
+    },
+    "flat": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-4.0.0.tgz",
+      "integrity": "sha512-ji/WMv2jdsE+LaznpkIF9Haax0sdpTBozrz/Dtg4qSRMfbs8oVg4ypJunIRYPiMLvH/ed6OflXbnbTIKJhtgeg==",
+      "requires": {
+        "is-buffer": "1.1.6"
+      }
+    },
+    "foreground-child": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
+      "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "4.0.2",
+        "signal-exit": "3.0.2"
+      }
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
+    },
+    "form-data": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+      "dev": true,
+      "requires": {
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.6",
+        "mime-types": "2.1.18"
+      }
+    },
+    "fs-exists-cached": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-exists-cached/-/fs-exists-cached-1.0.0.tgz",
+      "integrity": "sha1-zyVVTKBQ3EmuZla0HeQiWJidy84=",
+      "dev": true
+    },
+    "fs-extra": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+      "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "jsonfile": "4.0.0",
+        "universalify": "0.1.1"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "function-loop": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/function-loop/-/function-loop-1.0.1.tgz",
+      "integrity": "sha1-gHa7MF6OajzO7ikgdl8zDRkPNAw=",
+      "dev": true
+    },
+    "generate-function": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+      "dev": true
+    },
+    "generate-object-property": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "dev": true,
+      "requires": {
+        "is-property": "1.0.2"
+      }
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+    },
+    "har-validator": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+      "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "commander": "2.12.2",
+        "is-my-json-valid": "2.17.2",
+        "pinkie-promise": "2.0.1"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "hawk": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+      "dev": true,
+      "requires": {
+        "boom": "2.10.1",
+        "cryptiles": "2.0.5",
+        "hoek": "2.16.3",
+        "sntp": "1.0.9"
+      }
+    },
+    "hoek": {
+      "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+      "dev": true
+    },
+    "http-signature": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "0.2.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.13.1"
+      }
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+    },
+    "is-my-ip-valid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
+      "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
+      "dev": true
+    },
+    "is-my-json-valid": {
+      "version": "2.17.2",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
+      "integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
+      "dev": true,
+      "requires": {
+        "generate-function": "2.0.0",
+        "generate-object-property": "1.2.0",
+        "is-my-ip-valid": "1.0.0",
+        "jsonpointer": "4.0.1",
+        "xtend": "4.0.1"
+      }
+    },
+    "is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+      "dev": true
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true,
+      "optional": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+      "dev": true,
+      "requires": {
+        "argparse": "1.0.10",
+        "esprima": "4.0.0"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+          "dev": true
+        }
+      }
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true,
+      "optional": true
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
+    },
+    "json2csv": {
+      "version": "3.11.5",
+      "resolved": "https://registry.npmjs.org/json2csv/-/json2csv-3.11.5.tgz",
+      "integrity": "sha512-ORsw84BuRKMLxfI+HFZuvxRDnsJps53D5fIGr6tLn4ZY+ymcG8XU00E+JJ2wfAiHx5w2QRNmOLE8xHiGAeSfuQ==",
+      "requires": {
+        "cli-table": "0.3.1",
+        "commander": "2.12.2",
+        "debug": "3.1.0",
+        "flat": "4.0.0",
+        "lodash.clonedeep": "4.5.0",
+        "lodash.flatten": "4.4.0",
+        "lodash.get": "4.4.2",
+        "lodash.set": "4.3.2",
+        "lodash.uniq": "4.5.0",
+        "path-is-absolute": "1.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "requires": {
+        "graceful-fs": "4.1.11"
+      }
+    },
+    "jsonpointer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+      "dev": true
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "lcov-parse": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
+      "integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
+      "dev": true
+    },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+    },
+    "lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
+    "lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
+    },
+    "lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
+    },
+    "log-driver": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.5.tgz",
+      "integrity": "sha1-euTsJXMC/XkNVXyxDJcQDYV7AFY=",
+      "dev": true
+    },
+    "lru-cache": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+      "dev": true,
+      "requires": {
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
+      }
+    },
+    "mime-db": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+      "dev": true,
+      "requires": {
+        "mime-db": "1.33.0"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.11"
+      }
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "dev": true
+    },
+    "minipass": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.1.tgz",
+      "integrity": "sha512-u1aUllxPJUI07cOqzR7reGmQxmCqlH88uIIsf6XZFEWgw7gXKpJdR+5R9Y3KEDmWYkdIz9wXZs3C0jOPxejk/Q==",
+      "dev": true,
+      "requires": {
+        "yallist": "3.0.2"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
+          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
+          "dev": true
+        }
+      }
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        }
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "nan": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
+      "integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY="
+    },
+    "nyc": {
+      "version": "11.4.1",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.4.1.tgz",
+      "integrity": "sha512-5eCZpvaksFVjP2rt1r60cfXmt3MUtsQDw8bAzNqNEr4WLvUMLgiVENMf/B9bE9YAX0mGVvaGA3v9IS9ekNqB1Q==",
+      "dev": true,
+      "requires": {
+        "archy": "1.0.0",
+        "arrify": "1.0.1",
+        "caching-transform": "1.0.1",
+        "convert-source-map": "1.5.1",
+        "debug-log": "1.0.1",
+        "default-require-extensions": "1.0.0",
+        "find-cache-dir": "0.1.1",
+        "find-up": "2.1.0",
+        "foreground-child": "1.5.6",
+        "glob": "7.1.2",
+        "istanbul-lib-coverage": "1.1.1",
+        "istanbul-lib-hook": "1.1.0",
+        "istanbul-lib-instrument": "1.9.1",
+        "istanbul-lib-report": "1.1.2",
+        "istanbul-lib-source-maps": "1.2.2",
+        "istanbul-reports": "1.1.3",
+        "md5-hex": "1.3.0",
+        "merge-source-map": "1.0.4",
+        "micromatch": "2.3.11",
+        "mkdirp": "0.5.1",
+        "resolve-from": "2.0.0",
+        "rimraf": "2.6.2",
+        "signal-exit": "3.0.2",
+        "spawn-wrap": "1.4.2",
+        "test-exclude": "4.1.1",
+        "yargs": "10.0.3",
+        "yargs-parser": "8.0.0"
+      },
+      "dependencies": {
+        "align-text": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2",
+            "longest": "1.0.1",
+            "repeat-string": "1.6.1"
+          }
+        },
+        "amdefine": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "append-transform": {
+          "version": "0.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "default-require-extensions": "1.0.0"
+          }
+        },
+        "archy": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "arr-diff": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "arr-flatten": "1.1.0"
+          }
+        },
+        "arr-flatten": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "array-unique": {
+          "version": "0.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "arrify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "async": {
+          "version": "1.5.2",
+          "bundled": true,
+          "dev": true
+        },
+        "babel-code-frame": {
+          "version": "6.26.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "esutils": "2.0.2",
+            "js-tokens": "3.0.2"
+          }
+        },
+        "babel-generator": {
+          "version": "6.26.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0",
+            "detect-indent": "4.0.0",
+            "jsesc": "1.3.0",
+            "lodash": "4.17.4",
+            "source-map": "0.5.7",
+            "trim-right": "1.0.1"
+          }
+        },
+        "babel-messages": {
+          "version": "6.23.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.26.0"
+          }
+        },
+        "babel-runtime": {
+          "version": "6.26.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "core-js": "2.5.3",
+            "regenerator-runtime": "0.11.1"
+          }
+        },
+        "babel-template": {
+          "version": "6.26.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "lodash": "4.17.4"
+          }
+        },
+        "babel-traverse": {
+          "version": "6.26.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-code-frame": "6.26.0",
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "debug": "2.6.9",
+            "globals": "9.18.0",
+            "invariant": "2.2.2",
+            "lodash": "4.17.4"
+          }
+        },
+        "babel-types": {
+          "version": "6.26.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "esutils": "2.0.2",
+            "lodash": "4.17.4",
+            "to-fast-properties": "1.0.3"
+          }
+        },
+        "babylon": {
+          "version": "6.18.0",
+          "bundled": true,
+          "dev": true
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "1.1.8",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "braces": {
+          "version": "1.8.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "expand-range": "1.8.2",
+            "preserve": "0.2.0",
+            "repeat-element": "1.1.2"
+          }
+        },
+        "builtin-modules": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "caching-transform": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "md5-hex": "1.3.0",
+            "mkdirp": "0.5.1",
+            "write-file-atomic": "1.3.4"
+          }
+        },
+        "camelcase": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "center-align": {
+          "version": "0.1.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "align-text": "0.1.4",
+            "lazy-cache": "1.0.4"
+          }
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "cliui": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "center-align": "0.1.3",
+            "right-align": "0.1.3",
+            "wordwrap": "0.0.2"
+          },
+          "dependencies": {
+            "wordwrap": {
+              "version": "0.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "commondir": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "convert-source-map": {
+          "version": "1.5.1",
+          "bundled": true,
+          "dev": true
+        },
+        "core-js": {
+          "version": "2.5.3",
+          "bundled": true,
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "4.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lru-cache": "4.1.1",
+            "which": "1.3.0"
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "debug-log": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "decamelize": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "default-require-extensions": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "strip-bom": "2.0.0"
+          }
+        },
+        "detect-indent": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "repeating": "2.0.1"
+          }
+        },
+        "error-ex": {
+          "version": "1.3.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-arrayish": "0.2.1"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true
+        },
+        "esutils": {
+          "version": "2.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "execa": {
+          "version": "0.7.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
+          },
+          "dependencies": {
+            "cross-spawn": {
+              "version": "5.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "lru-cache": "4.1.1",
+                "shebang-command": "1.2.0",
+                "which": "1.3.0"
+              }
+            }
+          }
+        },
+        "expand-brackets": {
+          "version": "0.1.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-posix-bracket": "0.1.1"
+          }
+        },
+        "expand-range": {
+          "version": "1.8.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fill-range": "2.2.3"
+          }
+        },
+        "extglob": {
+          "version": "0.3.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
+        },
+        "filename-regex": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "fill-range": {
+          "version": "2.2.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-number": "2.1.0",
+            "isobject": "2.1.0",
+            "randomatic": "1.1.7",
+            "repeat-element": "1.1.2",
+            "repeat-string": "1.6.1"
+          }
+        },
+        "find-cache-dir": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "commondir": "1.0.1",
+            "mkdirp": "0.5.1",
+            "pkg-dir": "1.0.0"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        },
+        "for-in": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "for-own": {
+          "version": "0.1.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "for-in": "1.0.2"
+          }
+        },
+        "foreground-child": {
+          "version": "1.5.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cross-spawn": "4.0.2",
+            "signal-exit": "3.0.2"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "get-caller-file": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "glob-base": {
+          "version": "0.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob-parent": "2.0.0",
+            "is-glob": "2.0.1"
+          }
+        },
+        "glob-parent": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-glob": "2.0.1"
+          }
+        },
+        "globals": {
+          "version": "9.18.0",
+          "bundled": true,
+          "dev": true
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true,
+          "dev": true
+        },
+        "handlebars": {
+          "version": "4.0.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "async": "1.5.2",
+            "optimist": "0.6.1",
+            "source-map": "0.4.4",
+            "uglify-js": "2.8.29"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.4.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "amdefine": "1.0.1"
+              }
+            }
+          }
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "has-flag": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "hosted-git-info": {
+          "version": "2.5.0",
+          "bundled": true,
+          "dev": true
+        },
+        "imurmurhash": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "invariant": {
+          "version": "2.2.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loose-envify": "1.3.1"
+          }
+        },
+        "invert-kv": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-arrayish": {
+          "version": "0.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "is-buffer": {
+          "version": "1.1.6",
+          "bundled": true,
+          "dev": true
+        },
+        "is-builtin-module": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "builtin-modules": "1.1.1"
+          }
+        },
+        "is-dotfile": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "is-equal-shallow": {
+          "version": "0.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-primitive": "2.0.0"
+          }
+        },
+        "is-extendable": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "is-extglob": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-finite": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
+        },
+        "is-number": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          }
+        },
+        "is-posix-bracket": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "is-primitive": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-utf8": {
+          "version": "0.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "isexe": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "isobject": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "isarray": "1.0.0"
+          }
+        },
+        "istanbul-lib-coverage": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "istanbul-lib-hook": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "append-transform": "0.4.0"
+          }
+        },
+        "istanbul-lib-instrument": {
+          "version": "1.9.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-generator": "6.26.0",
+            "babel-template": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "istanbul-lib-coverage": "1.1.1",
+            "semver": "5.4.1"
+          }
+        },
+        "istanbul-lib-report": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "istanbul-lib-coverage": "1.1.1",
+            "mkdirp": "0.5.1",
+            "path-parse": "1.0.5",
+            "supports-color": "3.2.3"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "has-flag": "1.0.0"
+              }
+            }
+          }
+        },
+        "istanbul-lib-source-maps": {
+          "version": "1.2.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "debug": "3.1.0",
+            "istanbul-lib-coverage": "1.1.1",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.2",
+            "source-map": "0.5.7"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "3.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "istanbul-reports": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "handlebars": "4.0.11"
+          }
+        },
+        "js-tokens": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "jsesc": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        },
+        "lazy-cache": {
+          "version": "1.0.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "lcid": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "invert-kv": "1.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "p-locate": "2.0.0",
+            "path-exists": "3.0.0"
+          },
+          "dependencies": {
+            "path-exists": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "bundled": true,
+          "dev": true
+        },
+        "longest": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.3.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "js-tokens": "3.0.2"
+          }
+        },
+        "lru-cache": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
+          }
+        },
+        "md5-hex": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "md5-o-matic": "0.1.1"
+          }
+        },
+        "md5-o-matic": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "mem": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "mimic-fn": "1.1.0"
+          }
+        },
+        "merge-source-map": {
+          "version": "1.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "source-map": "0.5.7"
+          }
+        },
+        "micromatch": {
+          "version": "2.3.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "arr-diff": "2.0.0",
+            "array-unique": "0.2.1",
+            "braces": "1.8.5",
+            "expand-brackets": "0.1.5",
+            "extglob": "0.3.2",
+            "filename-regex": "2.0.1",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1",
+            "kind-of": "3.2.2",
+            "normalize-path": "2.1.1",
+            "object.omit": "2.0.1",
+            "parse-glob": "3.0.4",
+            "regex-cache": "0.4.4"
+          }
+        },
+        "mimic-fn": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "normalize-package-data": {
+          "version": "2.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "2.5.0",
+            "is-builtin-module": "1.0.0",
+            "semver": "5.4.1",
+            "validate-npm-package-license": "3.0.1"
+          }
+        },
+        "normalize-path": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "remove-trailing-separator": "1.1.0"
+          }
+        },
+        "npm-run-path": {
+          "version": "2.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "path-key": "2.0.1"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "object.omit": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "for-own": "0.1.5",
+            "is-extendable": "0.1.1"
+          }
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8",
+            "wordwrap": "0.0.3"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "os-locale": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "execa": "0.7.0",
+            "lcid": "1.0.0",
+            "mem": "1.1.0"
+          }
+        },
+        "p-finally": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "p-limit": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "p-limit": "1.1.0"
+          }
+        },
+        "parse-glob": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob-base": "0.3.0",
+            "is-dotfile": "1.0.3",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1"
+          }
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "error-ex": "1.3.1"
+          }
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "path-parse": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "bundled": true,
+          "dev": true
+        },
+        "pinkie": {
+          "version": "2.0.4",
+          "bundled": true,
+          "dev": true
+        },
+        "pinkie-promise": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "pinkie": "2.0.4"
+          }
+        },
+        "pkg-dir": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "find-up": "1.1.2"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "1.1.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "path-exists": "2.1.0",
+                "pinkie-promise": "2.0.1"
+              }
+            }
+          }
+        },
+        "preserve": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "pseudomap": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "randomatic": {
+          "version": "1.1.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-number": "3.0.0",
+            "kind-of": "4.0.0"
+          },
+          "dependencies": {
+            "is-number": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "3.2.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "1.1.6"
+                  }
+                }
+              }
+            },
+            "kind-of": {
+              "version": "4.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "1.1.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "find-up": "1.1.2",
+            "read-pkg": "1.1.0"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "1.1.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "path-exists": "2.1.0",
+                "pinkie-promise": "2.0.1"
+              }
+            }
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "bundled": true,
+          "dev": true
+        },
+        "regex-cache": {
+          "version": "0.4.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-equal-shallow": "0.1.3"
+          }
+        },
+        "remove-trailing-separator": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "repeat-element": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "repeat-string": {
+          "version": "1.6.1",
+          "bundled": true,
+          "dev": true
+        },
+        "repeating": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-finite": "1.0.2"
+          }
+        },
+        "require-directory": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "resolve-from": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "right-align": {
+          "version": "0.1.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "align-text": "0.1.4"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "semver": {
+          "version": "5.4.1",
+          "bundled": true,
+          "dev": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "shebang-regex": "1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "slide": {
+          "version": "1.1.6",
+          "bundled": true,
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "bundled": true,
+          "dev": true
+        },
+        "spawn-wrap": {
+          "version": "1.4.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "foreground-child": "1.5.6",
+            "mkdirp": "0.5.1",
+            "os-homedir": "1.0.2",
+            "rimraf": "2.6.2",
+            "signal-exit": "3.0.2",
+            "which": "1.3.0"
+          }
+        },
+        "spdx-correct": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "spdx-license-ids": "1.2.2"
+          }
+        },
+        "spdx-expression-parse": {
+          "version": "1.0.4",
+          "bundled": true,
+          "dev": true
+        },
+        "spdx-license-ids": {
+          "version": "1.2.2",
+          "bundled": true,
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ansi-regex": "3.0.0"
+              }
+            }
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-utf8": "0.2.1"
+          }
+        },
+        "strip-eof": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "test-exclude": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "arrify": "1.0.1",
+            "micromatch": "2.3.11",
+            "object-assign": "4.1.1",
+            "read-pkg-up": "1.0.1",
+            "require-main-filename": "1.0.1"
+          }
+        },
+        "to-fast-properties": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "trim-right": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "uglify-js": {
+          "version": "2.8.29",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "source-map": "0.5.7",
+            "uglify-to-browserify": "1.0.2",
+            "yargs": "3.10.0"
+          },
+          "dependencies": {
+            "yargs": {
+              "version": "3.10.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "camelcase": "1.2.1",
+                "cliui": "2.1.0",
+                "decamelize": "1.2.0",
+                "window-size": "0.1.0"
+              }
+            }
+          }
+        },
+        "uglify-to-browserify": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "validate-npm-package-license": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "spdx-correct": "1.0.2",
+            "spdx-expression-parse": "1.0.4"
+          }
+        },
+        "which": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "isexe": "2.0.0"
+          }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "window-size": {
+          "version": "0.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "wordwrap": {
+          "version": "0.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "wrap-ansi": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1"
+          },
+          "dependencies": {
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
+              }
+            }
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "write-file-atomic": {
+          "version": "1.3.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "imurmurhash": "0.1.4",
+            "slide": "1.1.6"
+          }
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "yargs": {
+          "version": "10.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "find-up": "2.1.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "2.1.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "8.0.0"
+          },
+          "dependencies": {
+            "cliui": {
+              "version": "3.2.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1",
+                "wrap-ansi": "2.1.0"
+              },
+              "dependencies": {
+                "string-width": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "code-point-at": "1.1.0",
+                    "is-fullwidth-code-point": "1.0.0",
+                    "strip-ansi": "3.0.1"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "yargs-parser": {
+          "version": "8.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "camelcase": "4.1.0"
+          },
+          "dependencies": {
+            "camelcase": {
+              "version": "4.1.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        }
+      }
+    },
+    "oauth-sign": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "opener": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.4.3.tgz",
+      "integrity": "sha1-XG2ixdflgx6P+jlklQ+NZnSskLg=",
+      "dev": true
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
+    },
+    "own-or": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/own-or/-/own-or-1.0.0.tgz",
+      "integrity": "sha1-Tod/vtqaLsgAD7wLyuOWRe6L+Nw=",
+      "dev": true
+    },
+    "own-or-env": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/own-or-env/-/own-or-env-1.0.1.tgz",
+      "integrity": "sha512-y8qULRbRAlL6x2+M0vIe7jJbJx/kmUTzYonRAa2ayesR2qWLswninkVyeJe4x3IEXhdgoNodzjQRKAoEs6Fmrw==",
+      "dev": true,
+      "requires": {
+        "own-or": "1.0.0"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "requires": {
+        "pinkie": "2.0.4"
+      }
+    },
+    "plist": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-2.1.0.tgz",
+      "integrity": "sha1-V8zbeggh3yGDEhejytVOPhRqECU=",
+      "requires": {
+        "base64-js": "1.2.0",
+        "xmlbuilder": "8.2.2",
+        "xmldom": "0.1.27"
+      }
+    },
+    "process-nextick-args": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+      "dev": true,
+      "optional": true
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
+    },
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+      "dev": true
+    },
+    "qs": {
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
+      "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
+      "dev": true
+    },
+    "readable-stream": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.4.tgz",
+      "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "2.0.0",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.0.3",
+        "util-deprecate": "1.0.2"
+      }
+    },
+    "request": {
+      "version": "2.79.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
+      "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
+      "dev": true,
+      "requires": {
+        "aws-sign2": "0.6.0",
+        "aws4": "1.6.0",
+        "caseless": "0.11.0",
+        "combined-stream": "1.0.6",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.1.4",
+        "har-validator": "2.0.6",
+        "hawk": "3.1.3",
+        "http-signature": "1.1.1",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.18",
+        "oauth-sign": "0.8.2",
+        "qs": "6.3.2",
+        "stringstream": "0.0.5",
+        "tough-cookie": "2.3.3",
+        "tunnel-agent": "0.4.3",
+        "uuid": "3.2.1"
+      }
+    },
+    "rimraf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "sntp": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+      "dev": true,
+      "requires": {
+        "hoek": "2.16.3"
+      }
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true
+    },
+    "source-map-support": {
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+      "dev": true,
+      "requires": {
+        "source-map": "0.5.7"
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "sqlite3": {
+      "version": "3.1.13",
+      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-3.1.13.tgz",
+      "integrity": "sha512-JxXKPJnkZ6NuHRojq+g2WXWBt3M1G9sjZaYiHEWSTGijDM3cwju/0T2XbWqMXFmPqDgw+iB7zKQvnns4bvzXlw==",
+      "requires": {
+        "nan": "2.7.0",
+        "node-pre-gyp": "0.6.38"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+        },
+        "ajv": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+          "requires": {
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
+          }
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.3.3"
+          }
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
+        },
+        "aws4": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+          "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+          "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+          "optional": true,
+          "requires": {
+            "tweetnacl": "0.14.5"
+          }
+        },
+        "block-stream": {
+          "version": "0.0.9",
+          "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+          "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+          "requires": {
+            "inherits": "2.0.3"
+          }
+        },
+        "boom": {
+          "version": "2.10.1",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.8",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+          "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+          "requires": {
+            "balanced-match": "1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+        },
+        "co": {
+          "version": "4.6.0",
+          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+          "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+          "requires": {
+            "boom": "2.10.1"
+          }
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+            }
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "extend": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+          "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+        },
+        "extsprintf": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+          "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.17"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+        },
+        "fstream": {
+          "version": "1.0.11",
+          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+          "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.2"
+          }
+        },
+        "fstream-ignore": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+          "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
+          "requires": {
+            "fstream": "1.0.11",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4"
+          }
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+          "requires": {
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          }
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+            }
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+        },
+        "har-schema": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+          "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
+        },
+        "har-validator": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+          "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+          "requires": {
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.13.1"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        },
+        "ini": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4="
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+          "optional": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+          "requires": {
+            "jsonify": "0.0.0"
+          }
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+        },
+        "jsonify": {
+          "version": "0.0.0",
+          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+          "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+        },
+        "jsprim": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+          "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.3.0",
+            "json-schema": "0.2.3",
+            "verror": "1.10.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+            }
+          }
+        },
+        "mime-db": {
+          "version": "1.30.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
+          "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
+        },
+        "mime-types": {
+          "version": "2.1.17",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+          "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+          "requires": {
+            "mime-db": "1.30.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "node-pre-gyp": {
+          "version": "0.6.38",
+          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.38.tgz",
+          "integrity": "sha1-6Sog+DQWQVu0CG9tH7eLPac9ET0=",
+          "requires": {
+            "hawk": "3.1.3",
+            "mkdirp": "0.5.1",
+            "nopt": "4.0.1",
+            "npmlog": "4.1.2",
+            "rc": "1.2.1",
+            "request": "2.81.0",
+            "rimraf": "2.6.2",
+            "semver": "5.4.1",
+            "tar": "2.2.1",
+            "tar-pack": "3.4.0"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+          "requires": {
+            "abbrev": "1.1.1",
+            "osenv": "0.1.4"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+        },
+        "once": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+        },
+        "osenv": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+          "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+        },
+        "performance-now": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+          "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+        },
+        "qs": {
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
+        },
+        "rc": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+          "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
+          "requires": {
+            "deep-extend": "0.4.2",
+            "ini": "1.3.4",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "request": {
+          "version": "2.81.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+          "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.17",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.1.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.3",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.1.0"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+        },
+        "semver": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "sshpk": {
+          "version": "1.13.1",
+          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+          "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+          "requires": {
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.1",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jsbn": "0.1.1",
+            "tweetnacl": "0.14.5"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+            }
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+          "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+        },
+        "tar": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+          "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+          "requires": {
+            "block-stream": "0.0.9",
+            "fstream": "1.0.11",
+            "inherits": "2.0.3"
+          }
+        },
+        "tar-pack": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
+          "integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
+          "requires": {
+            "debug": "2.6.9",
+            "fstream": "1.0.11",
+            "fstream-ignore": "1.0.5",
+            "once": "1.4.0",
+            "readable-stream": "2.3.3",
+            "rimraf": "2.6.2",
+            "tar": "2.2.1",
+            "uid-number": "0.0.6"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+          "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+          "requires": {
+            "punycode": "1.4.1"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+          "optional": true
+        },
+        "uid-number": {
+          "version": "0.0.6",
+          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+          "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE="
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+        },
+        "uuid": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+        },
+        "verror": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+          "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+          "requires": {
+            "assert-plus": "1.0.0",
+            "core-util-is": "1.0.2",
+            "extsprintf": "1.3.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+            }
+          }
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+          "requires": {
+            "string-width": "1.0.2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+        }
+      }
+    },
+    "sshpk": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+      "dev": true,
+      "requires": {
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "tweetnacl": "0.14.5"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "stack-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.1.tgz",
+      "integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA=",
+      "dev": true
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "stringstream": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+      "dev": true
+    },
+    "strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "requires": {
+        "ansi-regex": "3.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        }
+      }
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+    },
+    "tap": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/tap/-/tap-11.1.0.tgz",
+      "integrity": "sha512-ya7vl9gx+XFQn5K+Va/4AFz5U8ISAG22k6o+UoZAnX3Bx6uCwNtrsEzVvXjhOK2J+VybFHaReOF0TITDoCKSTQ==",
+      "dev": true,
+      "requires": {
+        "bind-obj-methods": "1.0.0",
+        "bluebird": "3.5.1",
+        "clean-yaml-object": "0.1.0",
+        "color-support": "1.1.3",
+        "coveralls": "2.13.3",
+        "foreground-child": "1.5.6",
+        "fs-exists-cached": "1.0.0",
+        "function-loop": "1.0.1",
+        "glob": "7.1.2",
+        "isexe": "2.0.0",
+        "js-yaml": "3.10.0",
+        "minipass": "2.2.1",
+        "mkdirp": "0.5.1",
+        "nyc": "11.4.1",
+        "opener": "1.4.3",
+        "os-homedir": "1.0.2",
+        "own-or": "1.0.0",
+        "own-or-env": "1.0.1",
+        "rimraf": "2.6.2",
+        "signal-exit": "3.0.2",
+        "source-map-support": "0.4.18",
+        "stack-utils": "1.0.1",
+        "tap-mocha-reporter": "3.0.6",
+        "tap-parser": "7.0.0",
+        "tmatch": "3.1.0",
+        "trivial-deferred": "1.0.1",
+        "tsame": "1.1.2",
+        "write-file-atomic": "2.3.0",
+        "yapool": "1.0.0"
+      }
+    },
+    "tap-mocha-reporter": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/tap-mocha-reporter/-/tap-mocha-reporter-3.0.6.tgz",
+      "integrity": "sha512-UImgw3etckDQCoqZIAIKcQDt0w1JLVs3v0yxLlmwvGLZl6MGFxF7JME5PElXjAoDklVDU42P3vVu5jgr37P4Yg==",
+      "dev": true,
+      "requires": {
+        "color-support": "1.1.3",
+        "debug": "2.6.9",
+        "diff": "1.4.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "js-yaml": "3.10.0",
+        "readable-stream": "2.3.4",
+        "tap-parser": "5.4.0",
+        "unicode-length": "1.0.3"
+      },
+      "dependencies": {
+        "tap-parser": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-5.4.0.tgz",
+          "integrity": "sha512-BIsIaGqv7uTQgTW1KLTMNPSEQf4zDDPgYOBRdgOfuB+JFOLRBfEu6cLa/KvMvmqggu1FKXDfitjLwsq4827RvA==",
+          "dev": true,
+          "requires": {
+            "events-to-array": "1.1.2",
+            "js-yaml": "3.10.0",
+            "readable-stream": "2.3.4"
+          }
+        }
+      }
+    },
+    "tap-parser": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-7.0.0.tgz",
+      "integrity": "sha512-05G8/LrzqOOFvZhhAk32wsGiPZ1lfUrl+iV7+OkKgfofZxiceZWMHkKmow71YsyVQ8IvGBP2EjcIjE5gL4l5lA==",
+      "dev": true,
+      "requires": {
+        "events-to-array": "1.1.2",
+        "js-yaml": "3.10.0",
+        "minipass": "2.2.1"
+      }
+    },
+    "tmatch": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tmatch/-/tmatch-3.1.0.tgz",
+      "integrity": "sha512-W3MSATOCN4pVu2qFxmJLIArSifeSOFqnfx9hiUaVgOmeRoI2NbU7RNga+6G+L8ojlFeQge+ZPCclWyUpQ8UeNQ==",
+      "dev": true
+    },
+    "tough-cookie": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+      "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+      "dev": true,
+      "requires": {
+        "punycode": "1.4.1"
+      }
+    },
+    "trivial-deferred": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trivial-deferred/-/trivial-deferred-1.0.1.tgz",
+      "integrity": "sha1-N21NKdlR1jaKb3oK6FwvTV4GWPM=",
+      "dev": true
+    },
+    "tsame": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tsame/-/tsame-1.1.2.tgz",
+      "integrity": "sha512-ovCs24PGjmByVPr9tSIOs/yjUX9sJl0grEmOsj9dZA/UknQkgPOKcUqM84aSCvt9awHuhc/boMzTg3BHFalxWw==",
+      "dev": true
+    },
+    "tunnel-agent": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+      "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+      "dev": true
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true,
+      "optional": true
+    },
+    "unicode-length": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/unicode-length/-/unicode-length-1.0.3.tgz",
+      "integrity": "sha1-Wtp6f+1RhBpBijKM8UlHisg1irs=",
+      "dev": true,
+      "requires": {
+        "punycode": "1.4.1",
+        "strip-ansi": "3.0.1"
+      },
+      "dependencies": {
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        }
+      }
+    },
+    "universalify": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
+      "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc="
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true,
+      "optional": true
+    },
+    "uuid": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
+      "dev": true
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "1.3.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "which": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "dev": true,
+      "requires": {
+        "isexe": "2.0.0"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "write-file-atomic": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
+      "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "imurmurhash": "0.1.4",
+        "signal-exit": "3.0.2"
+      }
+    },
+    "xmlbuilder": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
+      "integrity": "sha1-aSSGc0ELS6QuGmE2VR0pIjNap3M="
+    },
+    "xmldom": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
+      "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk="
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "dev": true
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
+    },
+    "yapool": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/yapool/-/yapool-1.0.0.tgz",
+      "integrity": "sha1-9pPymjFbUNmp2iZGp6ZkXJaYW2o=",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ibackuptool",
-  "version": "2.0.6",
+  "version": "3.0.0",
   "description": "Read Messages and info from iOS Backups",
   "main": "tools/index.js",
   "scripts": {
@@ -19,8 +19,12 @@
     "chalk": "^1.1.3",
     "commander": "^2.12.2",
     "fs-extra": "^4.0.3",
+    "json2csv": "^3.11.5",
     "plist": "^2.0.1",
     "sqlite3": "^3.1.8",
     "strip-ansi": "^4.0.0"
+  },
+  "devDependencies": {
+    "tap": "^11.1.0"
   }
 }

--- a/tests/test_version.js
+++ b/tests/test_version.js
@@ -1,0 +1,13 @@
+const tap = require('tap')
+const version = require('../tools/util/version_compare')
+
+tap.test('version', function (childTest) {
+    childTest.equal(version.versionCheck('9.1', '=9.1'), true)
+    childTest.equal(version.versionCheck('9.1', '<=9.1'), true)
+    childTest.equal(version.versionCheck('9.1', '>=9.1'), true)
+    childTest.equal(version.versionCheck('10.0', '<=9.1'), false)
+    childTest.equal(version.versionCheck('10.0', '<9.1'), false)
+    childTest.equal(version.versionCheck('10.0', '>9.1'), true)
+    childTest.equal(version.versionCheck('10.0', '>=9.1'), true)
+    childTest.end()
+})

--- a/tools/formatters/_default.js
+++ b/tools/formatters/_default.js
@@ -1,0 +1,19 @@
+const fs = require('fs-extra')
+const path = require('path')
+
+module.exports.finalReport = async function(reports, program) {
+    if (program.reportOutput === undefined) {
+      return
+    }
+    
+    // Ensure the output directory exists.
+    fs.ensureDirSync(program.reportOutput)
+
+    // Write each report to the disk
+    for(var report of reports) {
+      console.log('saving report', report.name)
+      var outPath = path.join(program.reportOutput, report.name + '.json')
+      console.log('writing to', outPath)
+      fs.writeFileSync(outPath, JSON.stringify(report.contents), 'utf8')
+    }
+  }

--- a/tools/formatters/_default.js
+++ b/tools/formatters/_default.js
@@ -11,9 +11,8 @@ module.exports.finalReport = async function(reports, program) {
 
     // Write each report to the disk
     for(var report of reports) {
-      console.log('saving report', report.name)
       var outPath = path.join(program.reportOutput, report.name + '.json')
-      console.log('writing to', outPath)
+      console.log('saving', outPath)
       fs.writeFileSync(outPath, JSON.stringify(report.contents), 'utf8')
     }
   }

--- a/tools/formatters/csv.js
+++ b/tools/formatters/csv.js
@@ -5,5 +5,7 @@ module.exports.format = function (data, options) {
     const csv = json2csv({ data })
 
     console.log(csv)
+
+    return csv
 }
   

--- a/tools/formatters/csv.js
+++ b/tools/formatters/csv.js
@@ -1,0 +1,9 @@
+const json2csv = require('json2csv')
+
+
+module.exports.format = function (data, options) {
+    const csv = json2csv({ data })
+
+    console.log(csv)
+}
+  

--- a/tools/formatters/csv.js
+++ b/tools/formatters/csv.js
@@ -2,10 +2,39 @@ const json2csv = require('json2csv')
 
 
 module.exports.format = function (data, options) {
-    const csv = json2csv({ data })
-
-    console.log(csv)
-
-    return csv
-}
+  const csv = json2csv({ data })
   
+  
+  if(options.program) {
+    // If reporting output is defined, ignore console log here.
+    if (options.program.reportOutput === undefined) {
+      console.log(csv)
+    }
+  } else {
+    console.log(csv)
+  }
+  
+  
+  return csv
+}
+
+const fs = require('fs-extra')
+const path = require('path')
+
+
+module.exports.finalReport = async function(reports, program) {
+  if (program.reportOutput === undefined) {
+    return
+  }
+  
+  // Ensure the output directory exists.
+  fs.ensureDirSync(program.reportOutput)
+
+  // Write each report to the disk
+  for(var report of reports) {
+    console.log('saving report', report.name)
+    var outPath = path.join(program.reportOutput, report.name + '.csv')
+    console.log('writing to', outPath)
+    fs.writeFileSync(outPath, report.contents, 'utf8')
+  }
+}

--- a/tools/formatters/json.js
+++ b/tools/formatters/json.js
@@ -1,3 +1,19 @@
 module.exports.format = function (data, options) {
-  console.log(JSON.stringify(data, 0, null, 2))
+  var data = data.map(el => {
+    var row = {}
+
+    // Iterate over the columns and add each item to the new row.
+    for (var key in options.columns) {
+      row[key] = options.columns[key](el)
+    }
+
+    return row
+  })
+
+  // Strigify the output, using 2 space indent.
+  var output = JSON.stringify(data, null, 2)
+
+  console.log(output)
+
+  return output
 }

--- a/tools/formatters/json.js
+++ b/tools/formatters/json.js
@@ -1,0 +1,3 @@
+module.exports.format = function (data, options) {
+  console.log(JSON.stringify(data, 0, null, 2))
+}

--- a/tools/formatters/json.js
+++ b/tools/formatters/json.js
@@ -57,9 +57,8 @@ module.exports.finalReport = async function(reports, program) {
     fs.ensureDirSync(program.reportOutput)
 
     for(var report of reports) {
-      console.log('saving report', report.name)
       var outPath = path.join(program.reportOutput, report.name + '.json')
-      console.log('writing to', outPath)
+      console.log('saving', outPath)
       fs.writeFileSync(outPath, JSON.stringify(report.contents, null, 2), 'utf8')
     }
   }

--- a/tools/formatters/json.js
+++ b/tools/formatters/json.js
@@ -1,19 +1,66 @@
 module.exports.format = function (data, options) {
   var data = data.map(el => {
     var row = {}
-
+    
     // Iterate over the columns and add each item to the new row.
     for (var key in options.columns) {
       row[key] = options.columns[key](el)
     }
-
+    
     return row
   })
-
+  
   // Strigify the output, using 2 space indent.
   var output = JSON.stringify(data, null, 2)
+  
+  if(options.program) {
+    // If reporting output is defined, ignore console log here.
+    if (options.program.reportOutput === undefined) {
+      console.log(output)
+    } else {
+      return data
+    }
+  } else {
+    console.log(output)
+  }
+  
+  return data
+}
 
-  console.log(output)
+const fs = require('fs-extra')
+const path = require('path')
 
-  return output
+module.exports.finalReport = async function(reports, program) {
+  if (program.reportOutput === undefined) {
+    return
+  }
+
+  if (program.joinReports) {
+    var out = {}
+
+    for(var report of reports) {
+      console.log('saving report', report.name)
+      out[report.name] = report.contents
+    }
+
+    if (program.reportOutput == '-') {
+      console.log(JSON.stringify(out, null, 2))
+    } else {
+      // fs.ensureDirSync(path.dirname(program.reportOutput))
+      //fs.copySync(sourceFile, outDir)
+      var outPath = program.reportOutput + '.json'
+      console.log('writing joined to', outPath)
+      fs.writeFileSync(outPath, JSON.stringify(out, null, 2), 'utf8')
+    }
+  } else {
+    console.log(program.reportOutput)
+    fs.ensureDirSync(program.reportOutput)
+
+    for(var report of reports) {
+      console.log('saving report', report.name)
+      var outPath = path.join(program.reportOutput, report.name + '.json')
+      console.log('writing to', outPath)
+      fs.writeFileSync(outPath, JSON.stringify(report.contents, null, 2), 'utf8')
+    }
+  }
 }

--- a/tools/formatters/raw-csv.js
+++ b/tools/formatters/raw-csv.js
@@ -2,17 +2,6 @@ const json2csv = require('json2csv')
 
 
 module.exports.format = function (data, options) {
-  var data = data.map(el => {
-    var row = {}
-    
-    // Iterate over the columns and add each item to the new row.
-    for (var key in options.columns) {
-      row[key] = options.columns[key](el)
-    }
-    
-    return row
-  })
-
   const csv = json2csv({ data })
   
   

--- a/tools/formatters/raw-json.js
+++ b/tools/formatters/raw-json.js
@@ -41,13 +41,13 @@ module.exports.finalReport = async function(reports, program) {
       fs.writeFileSync(outPath, JSON.stringify(out), 'utf8')
     }
   } else {
-    console.log(program.reportOutput)
+    // Ensure the output directory exists.
     fs.ensureDirSync(program.reportOutput)
 
+    // Write each report to the disk
     for(var report of reports) {
-      console.log('saving report', report.name)
       var outPath = path.join(program.reportOutput, report.name + '.json')
-      console.log('writing to', outPath)
+      console.log('saving', outPath)
       fs.writeFileSync(outPath, JSON.stringify(report.contents), 'utf8')
     }
   }

--- a/tools/formatters/raw.js
+++ b/tools/formatters/raw.js
@@ -1,0 +1,3 @@
+module.exports.format = function (data, options) {
+    console.log(JSON.stringify(data))
+}

--- a/tools/formatters/raw.js
+++ b/tools/formatters/raw.js
@@ -1,5 +1,55 @@
 module.exports.format = function (data, options) {
-    console.log(JSON.stringify(data))
+  var output = JSON.stringify(data)
 
-    return JSON.stringify(data)
+  if(options.program) {
+    // If reporting output is defined, ignore console log here.
+    if (options.program.reportOutput === undefined) {
+      console.log(output)
+    } else {
+        return data
+    }
+  } else {
+    console.log(output)
+  }
+
+  return data
 }
+
+const fs = require('fs-extra')
+const path = require('path')
+
+module.exports.finalReport = async function(reports, program) {
+  if (program.reportOutput === undefined) {
+    return
+  }
+
+  if (program.joinReports) {
+    var out = {}
+
+    for(var report of reports) {
+      console.log('saving report', report.name)
+      out[report.name] = report.contents
+    }
+
+    if (program.reportOutput == '-') {
+      console.log(JSON.stringify(out, null, 2))
+    } else {
+      // fs.ensureDirSync(path.dirname(program.reportOutput))
+      //fs.copySync(sourceFile, outDir)
+      var outPath = program.reportOutput + '.json'
+      console.log('writing joined to', outPath)
+      fs.writeFileSync(outPath, JSON.stringify(out), 'utf8')
+    }
+  } else {
+    console.log(program.reportOutput)
+    fs.ensureDirSync(program.reportOutput)
+
+    for(var report of reports) {
+      console.log('saving report', report.name)
+      var outPath = path.join(program.reportOutput, report.name + '.json')
+      console.log('writing to', outPath)
+      fs.writeFileSync(outPath, JSON.stringify(report.contents), 'utf8')
+    }
+  }
+}
+

--- a/tools/formatters/raw.js
+++ b/tools/formatters/raw.js
@@ -1,3 +1,5 @@
 module.exports.format = function (data, options) {
     console.log(JSON.stringify(data))
+
+    return JSON.stringify(data)
 }

--- a/tools/formatters/table.js
+++ b/tools/formatters/table.js
@@ -93,9 +93,8 @@ module.exports.finalReport = async function(reports, program) {
 
     // Write each report to the disk
     for(var report of reports) {
-      console.log('saving report', report.name)
       var outPath = path.join(program.reportOutput, report.name + '.txt')
-      console.log('writing to', outPath)
+      console.log('saving', outPath)
       fs.writeFileSync(outPath, report.contents, 'utf8')
     }
   }

--- a/tools/formatters/table.js
+++ b/tools/formatters/table.js
@@ -34,26 +34,30 @@ function normalizeCols (rows, max) {
 }
 
 function keyValueArray(columns, keys, obj) {
-  ///console.log(columns, keys, obj)
   return keys.map(el => columns[el](obj))
 }
 
 module.exports.format = function (data, options) {
-  //console.log(options)
+    // Keys for each column
     var keys = []
+
+    // Separators for each column
     var separators = []
     
+    // Add to collection of keys
     for(var key in options.columns) {
       keys.push(key)
       separators.push('-')
     }
 
+    // Create the rows
     var items = [
         keys,
         separators,
         ...data.map(data => keyValueArray(options.columns, keys, data))
     ]
 
+    // Normalize column widths.
     items = normalizeCols(items).map(el => {
       return el.join(' | ').replace(/\n/g, '')
     }).join('\n')
@@ -61,5 +65,7 @@ module.exports.format = function (data, options) {
     if (!options.color) { items = stripAnsi(items) }
 
     console.log(items)
+    
+    return items
 }
   

--- a/tools/formatters/table.js
+++ b/tools/formatters/table.js
@@ -62,10 +62,40 @@ module.exports.format = function (data, options) {
       return el.join(' | ').replace(/\n/g, '')
     }).join('\n')
 
-    if (!options.color) { items = stripAnsi(items) }
+    
 
-    console.log(items)
+    if(options.program) {
+
+      // Disable color output
+      if (!options.program.color) { items = stripAnsi(items) }
+
+      // If reporting output is defined, ignore console log here.
+      if (options.program.reportOutput === undefined) {
+        console.log(items)
+      }
+    } else {
+      console.log(items)
+    }
     
     return items
 }
-  
+
+const fs = require('fs-extra')
+const path = require('path')
+
+module.exports.finalReport = async function(reports, program) {
+    if (program.reportOutput === undefined) {
+      return
+    }
+    
+    // Ensure the output directory exists.
+    fs.ensureDirSync(program.reportOutput)
+
+    // Write each report to the disk
+    for(var report of reports) {
+      console.log('saving report', report.name)
+      var outPath = path.join(program.reportOutput, report.name + '.txt')
+      console.log('writing to', outPath)
+      fs.writeFileSync(outPath, report.contents, 'utf8')
+    }
+  }

--- a/tools/formatters/table.js
+++ b/tools/formatters/table.js
@@ -1,0 +1,65 @@
+const stripAnsi = require('strip-ansi')
+
+function normalizeCols (rows, max) {
+  function padEnd (string, maxLength, fillString) {
+    while ((stripAnsi(string) + '').length < maxLength) {
+      string = string + fillString
+    }
+
+    return string
+  }
+
+  var widths = []
+  max = max || rows[0].length
+
+  for (var i = 0; i < rows.length; i++) {
+    for (var j = 0; j < rows[i].length && j < max; j++) {
+      if (!widths[j] || widths[j] < (stripAnsi(rows[i][j]) + '').length) {
+        widths[j] = (stripAnsi(rows[i][j] + '') + '').length
+      }
+    }
+  }
+
+  for (var i = 0; i < rows.length; i++) {
+    for (var j = 0; j < rows[i].length && j < max; j++) {
+      if (rows[i][j] == '-') {
+        rows[i][j] = padEnd(rows[i][j], widths[j], '-')
+      } else {
+        rows[i][j] = padEnd(rows[i][j], widths[j], ' ')
+      }
+    }
+  }
+
+  return rows
+}
+
+function keyValueArray(columns, keys, obj) {
+  ///console.log(columns, keys, obj)
+  return keys.map(el => columns[el](obj))
+}
+
+module.exports.format = function (data, options) {
+  //console.log(options)
+    var keys = []
+    var separators = []
+    
+    for(var key in options.columns) {
+      keys.push(key)
+      separators.push('-')
+    }
+
+    var items = [
+        keys,
+        separators,
+        ...data.map(data => keyValueArray(options.columns, keys, data))
+    ]
+
+    items = normalizeCols(items).map(el => {
+      return el.join(' | ').replace(/\n/g, '')
+    }).join('\n')
+
+    if (!options.color) { items = stripAnsi(items) }
+
+    console.log(items)
+}
+  

--- a/tools/index.js
+++ b/tools/index.js
@@ -3,6 +3,8 @@
 const program = require('commander')
 const path = require('path')
 const chalk = require('chalk')
+const version = require('./util/version_compare')
+const iPhoneBackup = require('./util/iphone_backup.js').iPhoneBackup
 var base = path.join(process.env.HOME, '/Library/Application Support/MobileSync/Backup/')
 
 var reportTypes = {
@@ -21,18 +23,23 @@ var reportTypes = {
   'wifi': require('./reports/wifi')
 }
 
+var formatters = {
+  'json': require('./formatters/json'),
+  'table': require('./formatters/table'),
+  'raw': require('./formatters/raw'),
+  'csv': require('./formatters/csv')
+}
+
 program
     .version('2.0.5')
     .option('-l, --list', 'List Backups')
     .option(`-b, --backup <backup>`, 'Backup ID')
     .option('-r, --report <report_type>', 'Select a report type. see below for a full list.')
-    .option('-c, --conversations', 'List Conversations')
-    .option('-m, --messages <conversation_id>', 'List messages')
-    .option(`-e, --extract <dir>`, 'Extract data for commands. supported by: voicemail-files')
     .option(`-d, --dir <directory>`, `Backup Directory (default: ${base})`)
     .option(`-v, --verbose`, 'Verbose debugging output')
     .option(`-x, --no-color`, 'Disable colorized output')
-    .option('-z, --dump', 'Dump a ton of raw JSON formatted data instead of formatted output')
+    .option('-f, --formatter <type>', 'Specify output format. default: table')
+    .option(`-e, --extract <dir>`, 'Extract data for commands. supported by: voicemail-files')
 
 program.on('--help', function () {
   console.log('')
@@ -48,9 +55,19 @@ program.on('--help', function () {
   console.log("If you're interested to know how this works, check out my post:")
   console.log('https://www.richinfante.com/2017/3/16/reverse-engineering-the-ios-backup')
   console.log('')
+  console.log('Issue tracker:')
+  console.log('https://github.com/richinfante/iphonebackuptools/issues')
+  console.log('')
 })
 
 program.parse(process.argv)
+
+// Global verbose output flag.
+// This is bad
+global.verbose = program.verbose
+
+// Save the formatter
+program.formatter = formatters[program.formatter] || formatters.table
 
 if (!process.stdout.isTTY) { program.color = false }
 
@@ -72,18 +89,49 @@ if (program.list) {
   if (reportTypes[program.report]) {
     var report = reportTypes[program.report]
 
-        // Try to use it
+    if (report.requiresBackup) {
+      if (!program.backup) {
+        console.log('use -b or --backup <id> to specify backup.')
+        process.exit(1)
+      }
+    }
+
+    // Try to use it
     if (report.func) {
       try {
         report.func(program, base)
       } catch (e) {
         console.log('[!] Encountered an error', e)
       }
+    } else if (report.functions) {
+      // New type of reports
+      var backup = iPhoneBackup.fromID(program.backup, base)
+
+      var flag = false
+
+      // Check for a compatible reporting tool.
+      for (var key in report.functions) {
+        if (version.versionCheck(backup.iOSVersion, key)) {
+          report.functions[key](program, backup)
+          flag = true
+          break
+        }
+      }
+
+      if (!flag) {
+        console.log('[!] No compatible reporter for', backup.iOSVersion, 'and type', program.report)
+        console.log('')
+        console.log('    If you think one should exist, file an issue here:')
+        console.log('    https://github.com/richinfante/iphonebackuptools/issues')
+        console.log('')
+        process.exit(1)
+      }
     }
   } else {
     console.log('')
     console.log('  [!] Unknown Option type:', program.report)
     console.log('  [!] It\'s possible this tool is out-of date.')
+    console.log('  https://github.com/richinfante/iphonebackuptools/issues')
     console.log('')
     program.outputHelp()
   }

--- a/tools/index.js
+++ b/tools/index.js
@@ -31,26 +31,29 @@ var formatters = {
 }
 
 program
-    .version('3.0.0')
-    .option('-l, --list', 'List Backups')
-    .option(`-b, --backup <backup>`, 'Backup ID')
-    .option(`-d, --dir <directory>`, `Backup Directory (default: ${base})`)
-    .option('-r, --report <report_type>', 'Select a report type. see below for a full list.')
-    .option('-i, --id <id>', 'Specify an ID for filtering certain reports')
-    .option('-f, --formatter <type>', 'Specify output format. default: table')
-    .option(`-e, --extract <dir>`, 'Extract data for commands. supported by: voicemail-files')
-    .option(`-f, --filter <filter>`, 'Filter output for individual reports. See the README for usage.')
-    .option(`-v, --verbose`, 'Verbose debugging output')
-    .option(`-x, --no-color`, 'Disable colorized output')
+.version('3.0.0')
+.option('-l, --list', 'List Backups')
+.option(`-b, --backup <backup>`, 'Backup ID')
+.option(`-d, --dir <directory>`, `Backup Directory (default: ${base})`)
+.option('-r, --report <report_type>', 'Select a report type. see below for a full list.')
+.option('-i, --id <id>', 'Specify an ID for filtering certain reports')
+.option('-f, --formatter <type>', 'Specify output format. default: table')
+.option(`-e, --extract <dir>`, 'Extract data for commands. supported by: voicemail-files, manifest')
+.option('-o, --report-output <path>', 'Specify an output directory for files to be written to.')
+.option(`-v, --verbose`, 'Verbose debugging output')
+.option(`    --filter <filter>`, 'Filter output for individual reports. See the README for usage.')
+.option('    --join-reports', 'Join JSON reports together. (available for -f json or -f raw only!)')
+.option(`    --no-color`, 'Disable colorized output')
 
 program.on('--help', function () {
   console.log('')
   console.log('Supported Report Types:')
   for (var i in reportTypes) {
+    var r = reportTypes[i]
     if (program.isTTY) {
-      console.log('  ', reportTypes[i].name, '-', reportTypes[i].description)
+      console.log('  ', r.name, (r.supportedVersions ? '(iOS ' + r.supportedVersions + ')' : ' ') + '-', r.description)
     } else {
-      console.log('  ', chalk.green(reportTypes[i].name), '-', reportTypes[i].description)
+      console.log('  ', chalk.green(r.name), (r.supportedVersions ? chalk.gray('(iOS ' + r.supportedVersions + ') ') : '') + '-', r.description)
     }
   }
   console.log('')
@@ -62,6 +65,7 @@ program.on('--help', function () {
   console.log('')
 })
 
+// Parse argv.
 program.parse(process.argv)
 
 // Global verbose output flag.
@@ -71,91 +75,192 @@ global.verbose = program.verbose
 // Save the formatter
 program.formatter = formatters[program.formatter] || formatters.table
 
+// Disable color for non-ttys.
 if (!process.stdout.isTTY) { program.color = false }
 
+// Find the base
 base = program.dir || base
 
 if (program.verbose) console.log('Using source:', base)
 
-if (program.list) {
-    // Shortcut for list report
-  reportTypes.list.func(program, base)
-} else if (program.report) {
-    // If the report is valid
-  if (reportTypes[program.report]) {
-    var report = reportTypes[program.report]
+// Run the main function
+main()
 
-    // Check if there's a backup specified and one is required.
-    if (report.requiresBackup) {
-      if (!program.backup) {
-        console.log('use -b or --backup <id> to specify backup.')
-        process.exit(1)
+async function main() {
+  if (program.list) {
+    // Run the list report standalone
+    let result = await new Promise((resolve, reject) => {
+      reportTypes.list.func(program, base, resolve, reject)
+    })
+  } else if (program.report) {
+    var reportContents = [] 
+
+    // Turn the report argument into an array of report type names
+    var selectedTypes = program.report
+      .split(',')
+      .map(el => el.trim())
+      .filter(el => el != '')
+
+    // Add all types if type is 'all'
+    if (program.report == 'all') {
+      selectedTypes = []
+
+      for (var key in reportTypes) {
+        if (reportTypes[key].requiresInteractivity === true) {
+          continue
+        }
+
+        selectedTypes.push(key)  
+      }
+    }
+    
+    for(var reportName of selectedTypes) {
+      // If the report is valid
+      if (reportTypes[reportName]) {
+        
+        var report = reportTypes[reportName]
+
+        if(selectedTypes.length > 1 && !report.usesPromises) {
+          console.log('Warning: report that does not utilize promises in multi-request.')
+          console.log('Warning: this may not work.')
+        }
+        
+        // Check if there's a backup specified and one is required.
+        if (report.requiresBackup) {
+          if (!program.backup) {
+            console.log('use -b or --backup <id> to specify backup.')
+            process.exit(1)
+          }
+        }
+        
+        if (report.func) {
+          var report = await runSingleReport(report, program)
+
+          reportContents.push({ 
+            name: reportName, 
+            contents: report
+          })
+        } else if (report.functions) {
+          var report = await runSwitchedReport(report, program)
+
+          reportContents.push({ 
+            name: reportName, 
+            contents: report
+          })
+        }
+      } else {
+        console.log('')
+        console.log('  [!] Unknown Option type:', reportName)
+        console.log('  [!] It\'s possible this tool is out-of date.')
+        console.log('  https://github.com/richinfante/iphonebackuptools/issues')
+        console.log('')
+        program.outputHelp()
       }
     }
 
-    // Try to use it
-    if (report.func) {
-      try {
-        // New type of reports
-        var backup = iPhoneBackup.fromID(program.backup, base)
-        
-        if (report.supportedVersions !== undefined) {
-          if (version.versionCheck(backup.iOSVersion, report.supportedVersions)) {
-            if (report.requiresBackup) {
-              report.func(program, backup)
-            } else {
-              report.func(program, base)
-            }
-          } else {
-            console.log('[!] The report generator "' + program.report + '" does not support iOS', backup.iOSVersion)
-            console.log('')
-            console.log('    If you think it should, file an issue here:')
-            console.log('    https://github.com/richinfante/iphonebackuptools/issues')
-            console.log('')
-            process.exit(1)
-          }
+    program.formatter.finalReport(reportContents, program)
+  } else {
+    program.outputHelp()
+  }
+}
+
+async function runSwitchedReport(report, program) {
+  try {
+    // New type of reports
+    var backup = iPhoneBackup.fromID(program.backup, base)
+          
+    var flag = false
+    var value
+    // Check for a compatible reporting tool.
+    for (var key in report.functions) {
+      if (version.versionCheck(backup.iOSVersion, key)) {
+        if(!report.usesPromises) {
+          if(program.verbose) console.log('using synchronous call.')
+            
+          value = report.functions[key](program, backup)
         } else {
-          if (report.requiresBackup) {
-            report.func(program, backup)
-          } else {
-            report.func(program, base)
+          // Create a promise to resolve this function
+          async function createPromise() {
+            if(program.verbose) console.log('resolving using promises.')
+            
+            return new Promise((resolve, reject) => {
+              report.functions[key](program, backup, resolve, reject)
+            })
           }
+
+          // Use promises to resolve synchronously
+          value = await createPromise()
         }
-      } catch (e) {
-        console.log('[!] Encountered an error', e)
+        flag = true
+        break
       }
-    } else if (report.functions) {
-      // New type of reports
-      var backup = iPhoneBackup.fromID(program.backup, base)
+    }
+    
+    if (!flag) {
+      console.log('[!] The report generator "', program.report,'" does not support iOS', backup.iOSVersion)
+      console.log('')
+      console.log('    If you think it should, file an issue here:')
+      console.log('    https://github.com/richinfante/iphonebackuptools/issues')
+      console.log('')
+      process.exit(1)
+    }
 
-      var flag = false
+    return value
+  } catch (e) {
+    console.log('[!] Encountered an error', e)
+  }
+}
 
-      // Check for a compatible reporting tool.
-      for (var key in report.functions) {
-        if (version.versionCheck(backup.iOSVersion, key)) {
-          report.functions[key](program, backup)
-          flag = true
-          break
-        }
+async function runSingleReport(report, program) {
+  async function runReport(backup, base) {
+    if(!report.usesPromises) {
+      if(program.verbose) console.log('using synchronous call.')
+
+      // Old-style non-promise based report.
+      if (report.requiresBackup) {
+        return report.func(program, backup)
+      } else {
+        return report.func(program, base)
+      }
+    } else {
+      // Create a promise to resolve this function
+      async  function createPromise() {
+        if(program.verbose) console.log('resolving using promises.')
+        
+        return new Promise((resolve, reject) => {
+          if (report.requiresBackup) {
+            report.func(program, backup, resolve, reject)
+          } else {
+            report.func(program, base, resolve, reject)
+          }
+        })
       }
 
-      if (!flag) {
-        console.log('[!] The report generator "', program.report,'" does not support iOS', backup.iOSVersion)
+      // Use promises to resolve synchronously
+      return await createPromise()
+    }
+  }
+
+
+  try {
+    // New type of reports
+    var backup = iPhoneBackup.fromID(program.backup, base)
+    
+    if (report.supportedVersions !== undefined) {
+      if (version.versionCheck(backup.iOSVersion, report.supportedVersions)) {
+        return await runReport(backup, base)
+      } else {
+        console.log('[!] The report generator "' + program.report + '" does not support iOS', backup.iOSVersion)
         console.log('')
         console.log('    If you think it should, file an issue here:')
         console.log('    https://github.com/richinfante/iphonebackuptools/issues')
         console.log('')
         process.exit(1)
       }
+    } else {
+      return await runReport(backup, base)
     }
-  } else {
-    console.log('')
-    console.log('  [!] Unknown Option type:', program.report)
-    console.log('  [!] It\'s possible this tool is out-of date.')
-    console.log('  https://github.com/richinfante/iphonebackuptools/issues')
-    console.log('')
-    program.outputHelp()
+  } catch (e) {
+    console.log('[!] Encountered an error', e)
   }
-} else {
-  program.outputHelp()
 }

--- a/tools/index.js
+++ b/tools/index.js
@@ -46,10 +46,13 @@ program
 .option(`    --filter <filter>`, 'Filter output for individual reports. See the README for usage.')
 .option('    --join-reports', 'Join JSON reports together. (available for -f json or -f raw only!)')
 .option(`    --no-color`, 'Disable colorized output')
+.option(`    --dump`, 'alias for "--formatter raw"')
 
 program.on('--help', function () {
   console.log('')
   console.log('Supported Report Types:')
+
+  // Generate a list of report types.
   for (var i in reportTypes) {
     var r = reportTypes[i]
     if (program.isTTY) {
@@ -76,6 +79,11 @@ global.verbose = program.verbose
 
 // Save the formatter
 program.formatter = formatters[program.formatter] || formatters.table
+
+// Legacy support for `--dump` flag.
+if (program.dump) {
+  program.formatter = formatters.raw
+}
 
 // Disable color for non-ttys.
 if (!process.stdout.isTTY) { program.color = false }

--- a/tools/index.js
+++ b/tools/index.js
@@ -26,8 +26,10 @@ var reportTypes = {
 var formatters = {
   'json': require('./formatters/json'),
   'table': require('./formatters/table'),
-  'raw': require('./formatters/raw'),
-  'csv': require('./formatters/csv')
+  'raw':  require('./formatters/raw-json'),
+  'raw-json': require('./formatters/raw-json'),
+  'csv': require('./formatters/csv'),
+  'raw-csv': require('./formatters/raw-csv'),
 }
 
 program

--- a/tools/reports/_example.js
+++ b/tools/reports/_example.js
@@ -8,12 +8,27 @@ module.exports.description = 'An example module to show how it works'
 // The second parameter to func() is now a backup instead of the path to one.
 module.exports.requiresBackup = true
 
+// Should this report be skipped in automated reports?
+// This is used when the 'all' report type is specified, and all possible reports are generated.
+// with this set to true, the report WILL NOT run when report type = 'all'
+module.exports.requiresInteractivity = true
+
+// Specify this reporter supports the promises API for allowing chaining of reports.
+module.exports.usesPromises = true
+
 // Specify this only works for iOS 10+
 module.exports.supportedVersions = '>=10.0'
 
-// Reporting function
+// Reporting function (for usesPromises = false)
 module.exports.func = function (program, backup) {
   // This function will be called with the `commander` program, and the iPhoneBackup instance as arguments
+  // This is deprecated.
+}
+
+// Reporting function (for usesPromises = true)
+module.exports.func = function (program, backup, resolve, reject) {
+    // This function will be called with the `commander` program, and the iPhoneBackup instance as arguments
+    // It MUST resolve() the final result, or reject() if there's an error
 }
 
 // --- OR ---

--- a/tools/reports/_example.js
+++ b/tools/reports/_example.js
@@ -1,0 +1,30 @@
+// Name of the module.
+module.exports.name = 'example module'
+
+// Description of the module
+module.exports.description = 'An example module to show how it works'
+
+// Specify this reporter requires a backup. 
+// The second parameter to func() is now a backup instead of the path to one.
+module.exports.requiresBackup = true
+
+// Specify this only works for iOS 10+
+module.exports.supportedVersions = '>=10.0'
+
+// Reporting function
+module.exports.func = function (program, backup) {
+  // This function will be called with the `commander` program, and the iPhoneBackup instance as arguments
+}
+
+// --- OR ---
+
+// You can also provide an array of functions instead of using `module.exports.func`.
+// These functions *should* be independent ranges to ensure reliable execution
+module.exports.functions = {
+    '>=10.0': function(program,backup) {
+        // This function would be called for iOS 10+
+    }, 
+    '>=9.0,<10.0': function(program,backup) {
+        // This function would be called for all iOS 9.
+    }
+}

--- a/tools/reports/apps.js
+++ b/tools/reports/apps.js
@@ -3,24 +3,26 @@ const iPhoneBackup = require('../util/iphone_backup.js').iPhoneBackup
 module.exports.name = 'apps'
 module.exports.description = 'List all installed applications and container IDs.'
 
+module.exports.compatible_versions = [ '>=10.0' ]
+
 module.exports.func = function (program, base) {
   if (!program.backup) {
     console.log('use -b or --backup <id> to specify backup.')
     process.exit(1)
   }
 
-        // Grab the backup
+  // Grab the backup
   var backup = iPhoneBackup.fromID(program.backup, base)
 
   if (!backup.manifest) return {}
 
-        // Possibly dump output
+  // Possibly dump output
   if (program.dump) {
     console.log(JSON.stringify(backup.manifest, null, 4))
     return
   }
 
-        // Enumerate the apps in the backup
+  // Enumerate the apps in the backup
   var apps = []
   for (var key in backup.manifest.Applications) {
     apps.push(key)

--- a/tools/reports/apps.js
+++ b/tools/reports/apps.js
@@ -3,8 +3,6 @@ const iPhoneBackup = require('../util/iphone_backup.js').iPhoneBackup
 module.exports.name = 'apps'
 module.exports.description = 'List all installed applications and container IDs.'
 
-module.exports.compatible_versions = [ '>=10.0' ]
-
 module.exports.func = function (program, base) {
   if (!program.backup) {
     console.log('use -b or --backup <id> to specify backup.')

--- a/tools/reports/apps.js
+++ b/tools/reports/apps.js
@@ -3,29 +3,32 @@ const iPhoneBackup = require('../util/iphone_backup.js').iPhoneBackup
 module.exports.name = 'apps'
 module.exports.description = 'List all installed applications and container IDs.'
 
-module.exports.func = function (program, base) {
-  if (!program.backup) {
-    console.log('use -b or --backup <id> to specify backup.')
-    process.exit(1)
-  }
+// Specify this reporter requires a backup. 
+// The second parameter to func() is now a backup instead of the path to one.
+module.exports.requiresBackup = true
 
-  // Grab the backup
-  var backup = iPhoneBackup.fromID(program.backup, base)
+// Specify this reporter supports the promises API for allowing chaining of reports.
+module.exports.usesPromises = true
 
-  if (!backup.manifest) return {}
+module.exports.func = function (program, backup, resolve, reject) {
 
-  // Possibly dump output
-  if (program.dump) {
-    console.log(JSON.stringify(backup.manifest, null, 4))
-    return
-  }
+  if (!backup.manifest) return reject(new Error('Manifest does not exist in this version'))
 
   // Enumerate the apps in the backup
   var apps = []
   for (var key in backup.manifest.Applications) {
-    apps.push(key)
+    var app = backup.manifest.Applications[key]
+
+    apps.push({ bundleID: app.CFBundleIdentifier, path:  app.Path})
   }
 
-  console.log(`Apps installed inside backup: ${backup.id}`)
-  console.log(apps.map(el => '- ' + el).join('\n'))
+  var result = program.formatter.format(apps, {
+    program: program,
+    columns: {
+      'Bundle ID': el => el.bundleID,
+      'Bundle Path': el => el.path
+    }
+  })
+
+  resolve(result)
 }

--- a/tools/reports/calls.js
+++ b/tools/reports/calls.js
@@ -1,45 +1,39 @@
 module.exports.name = 'calls'
 module.exports.description = 'List all call records contained in the backup.'
+
+// Specify this reporter requires a backup. 
+// The second parameter to func() is now a backup instead of the path to one.
 module.exports.requiresBackup = true
-module.exports.functions = {
 
-  //
-  // iOS 9+ Call Log Extraction
-  //
-  '>=9.0': function (program, backup) {
-    // File ID for calls is `5a4935c78a5255723f707230a451d79c540d2741`
+// Specify this only works for iOS 10+
+module.exports.supportedVersions = '>=10.0'
 
-    backup.queryDatabase('5a4935c78a5255723f707230a451d79c540d2741',
-    `
-      SELECT *, 
-      datetime(ZDATE + 978307200, 'unixepoch') AS XFORMATTEDDATESTRING 
-      FROM ZCALLRECORD 
-      ORDER BY ZDATE ASC
-    `)
-    .then((items) => {
-      // Use the configured formatter to print the rows.
-      program.formatter.format(items, {
-        // Color formatting?
-        color: program.color,
+module.exports.func = function (program, backup) {
 
-        // Columns to be displayed in human-readable printouts.
-        // Some formatters, like raw or CSV, ignore these.
-        columns: {
-          'ID': el => el.Z_PK,
-          'Date': el => el.XFORMATTEDDATESTRING,
-          'Answered': el => el.ZANSWERED + '',
-          'Originated': el => el.ZORIGINATED + '',
-          'Call Type': el => el.ZCALLTYPE + '',
-          'Duration': el => el.ZDURATION + '',
-          'Location': el => el.ZLOCATION + '',
-          'Country': el => el.ZISO_COUNTRY_CODE + '',
-          'Service': el => el.ZSERVICE_PROVIDER + '',
-          'Address': el => (el.ZADDRESS || '').toString()
-        }
-      })
+  backup.getCallsList()
+  .then((items) => {
+    // Use the configured formatter to print the rows.
+    program.formatter.format(items, {
+      // Color formatting?
+      color: program.color,
+
+      // Columns to be displayed in human-readable printouts.
+      // Some formatters, like raw or CSV, ignore these.
+      columns: {
+        'ID': el => el.Z_PK,
+        'Date': el => el.XFORMATTEDDATESTRING,
+        'Answered': el => el.ZANSWERED + '',
+        'Originated': el => el.ZORIGINATED + '',
+        'Call Type': el => el.ZCALLTYPE + '',
+        'Duration': el => el.ZDURATION + '',
+        'Location': el => el.ZLOCATION + '',
+        'Country': el => el.ZISO_COUNTRY_CODE + '',
+        'Service': el => el.ZSERVICE_PROVIDER + '',
+        'Address': el => (el.ZADDRESS || '').toString()
+      }
     })
-    .catch((e) => {
-      console.log('[!] Encountered an Error:', e)
-    })
-  }
+  })
+  .catch((e) => {
+    console.log('[!] Encountered an Error:', e)
+  })
 }

--- a/tools/reports/calls.js
+++ b/tools/reports/calls.js
@@ -5,17 +5,21 @@ module.exports.description = 'List all call records contained in the backup.'
 // The second parameter to func() is now a backup instead of the path to one.
 module.exports.requiresBackup = true
 
+// Specify this reporter supports the promises API for allowing chaining of reports.
+module.exports.usesPromises = true
+
 // Specify this only works for iOS 10+
 module.exports.supportedVersions = '>=10.0'
 
-module.exports.func = function (program, backup) {
+module.exports.func = function (program, backup, resolve, reject) {
 
   backup.getCallsList()
   .then((items) => {
+
     // Use the configured formatter to print the rows.
-    program.formatter.format(items, {
+    const result = program.formatter.format(items, {
       // Color formatting?
-      color: program.color,
+      program: program,
 
       // Columns to be displayed in human-readable printouts.
       // Some formatters, like raw or CSV, ignore these.
@@ -32,8 +36,9 @@ module.exports.func = function (program, backup) {
         'Address': el => (el.ZADDRESS || '').toString()
       }
     })
+
+    // If using promises, we must call resolve()
+    resolve(result)
   })
-  .catch((e) => {
-    console.log('[!] Encountered an Error:', e)
-  })
+  .catch(reject)
 }

--- a/tools/reports/conversations.js
+++ b/tools/reports/conversations.js
@@ -6,20 +6,19 @@ const normalizeCols = require('../util/normalize.js')
 module.exports.name = 'conversations'
 module.exports.description = 'List all SMS and iMessage conversations'
 
-module.exports.func = function (program, base) {
-  if (!program.backup) {
-    console.log('use -b or --backup <id> to specify backup.')
-    process.exit(1)
-  }
+// Specify this reporter requires a backup. 
+// The second parameter to func() is now a backup instead of the path to one.
+module.exports.requiresBackup = true
 
-  // Grab the backup
-  var backup = iPhoneBackup.fromID(program.backup, base)
+// Specify this reporter supports the promises API for allowing chaining of reports.
+module.exports.usesPromises = true
 
+module.exports.func = function (program, backup, resolve, reject) {
   backup.getConversations()
     .then((items) => {
 
-      program.formatter.format(items, {
-        color: program.color,
+      var result = program.formatter.format(items, {
+        program: program,
         columns: {
           'ID': el => el.ROWID,
           'Date': el => el.XFORMATTEDDATESTRING || '??',
@@ -28,8 +27,8 @@ module.exports.func = function (program, base) {
           'Display Name': el => el.display_name + '',
         }
       })
+
+      resolve(result)
     })
-    .catch((e) => {
-      console.log('[!] Encountered an Error:', e)
-    })
+    .catch(reject)
 }

--- a/tools/reports/conversations.js
+++ b/tools/reports/conversations.js
@@ -15,24 +15,19 @@ module.exports.func = function (program, base) {
   // Grab the backup
   var backup = iPhoneBackup.fromID(program.backup, base)
 
-  backup.getConversations(program.dump)
+  backup.getConversations()
     .then((items) => {
-      if (program.dump) return
 
-      items = items.map(el => [
-        el.ROWID + '',
-        chalk.gray(el.XFORMATTEDDATESTRING || '??'),
-        el.service_name + '', 
-        el.chat_identifier + '',
-        el.display_name + ''
-      ])
-
-      items = [['ID', 'DATE', 'Service', 'Chat Name', 'Display Name'], ['-', '-', '-', '-', '-'], ...items]
-      items = normalizeCols(items).map(el => el.join(' | ')).join('\n')
-
-      if (!program.color) { items = stripAnsi(items) }
-
-      console.log(items)
+      program.formatter.format(items, {
+        color: program.color,
+        columns: {
+          'ID': el => el.ROWID,
+          'Date': el => el.XFORMATTEDDATESTRING || '??',
+          'Service': el => el.service_name + '',
+          'Chat Name': el => el.chat_identifier + '',
+          'Display Name': el => el.display_name + '',
+        }
+      })
     })
     .catch((e) => {
       console.log('[!] Encountered an Error:', e)

--- a/tools/reports/list.js
+++ b/tools/reports/list.js
@@ -7,20 +7,25 @@ const fs = require('fs-extra')
 module.exports.name = 'list'
 module.exports.description = 'List of all backups. alias for -l'
 
-module.exports.func = function (program, base) {
+
+// Specify this reporter requires a backup. 
+// The second parameter to func() is now a backup instead of the path to one.
+module.exports.requiresBackup = false
+
+// Specify this reporter supports the promises API for allowing chaining of reports.
+module.exports.usesPromises = true
+
+module.exports.func = function (program, base, resolve, reject) {
   var items = fs.readdirSync(base, { encoding: 'utf8' })
     .filter(el => (el !== '.DS_Store'))
     .map(file => iPhoneBackup.fromID(file, base))
     .filter(el => el.manifest && el.status)
 
-  program.formatter.format(items, {
-    color: program.color,
+  var output = program.formatter.format(items, {
+    program: program,
     columns: {
       'UDID': el => el.id,
-      'Encryption': el => el.manifest ? el.manifest.IsEncrypted
-                                      ? chalk.green('encrypted')
-                                        : chalk.red('not encrypted')
-                                      : 'unknown encryption',
+      'Encryption': el => el.manifest ? (el.manifest.IsEncrypted ? 'encrypted' : 'not encrypted') : 'unknown',
       'Date': el => el.status ? new Date(el.status.Date).toLocaleString() : '',
       'Device Name': el => el.manifest ? el.manifest.Lockdown.DeviceName : 'Unknown Device',
       'Serial #': el => el.manifest.Lockdown.SerialNumber,
@@ -28,4 +33,6 @@ module.exports.func = function (program, base) {
       'Backup Version': el => el.status ? el.status.Version : '?'
     }
   })
+
+  resolve(output)
 }

--- a/tools/reports/list.js
+++ b/tools/reports/list.js
@@ -24,7 +24,7 @@ module.exports.func = function (program, base) {
       'Date': el => el.status ? new Date(el.status.Date).toLocaleString() : '',
       'Device Name': el => el.manifest ? el.manifest.Lockdown.DeviceName : 'Unknown Device',
       'Serial #': el => el.manifest.Lockdown.SerialNumber,
-      'iOS Version': el => el.status ? el.status.Version : '?',
+      'iOS Version': el => el.manifest ? el.manifest.Lockdown.ProductVersion : '?',
       'Backup Version': el => el.status ? el.status.Version : '?'
     }
   })

--- a/tools/reports/manifest.js
+++ b/tools/reports/manifest.js
@@ -6,33 +6,33 @@ module.exports.name = 'manifest'
 module.exports.description = 'List all the files contained in the backup (iOS 10+)'
 
 module.exports.func = function (program, base) {
-  if (!program.backup) {
-    console.log('use -b or --backup <id> to specify backup.')
-    process.exit(1)
-  }
-
-// Grab the backup
-  var backup = iPhoneBackup.fromID(program.backup, base)
-  backup.getFileManifest()
+    if (!program.backup) {
+        console.log('use -b or --backup <id> to specify backup.')
+        process.exit(1)
+    }
+    
+    // Grab the backup
+    var backup = iPhoneBackup.fromID(program.backup, base)
+    backup.getFileManifest()
     .then((items) => {
-      if (program.dump) {
-        console.log(JSON.stringify(items, null, 4))
-        return
-      }
-
-      items = items.map(el => [
-        el.fileID + '',
-        el.domain + ': ' + el.relativePath
-      ])
-
-      items = [['ID', 'Domain/Path'], ['-'], ...items]
-      items = normalizeCols(items, 1).map(el => el.join(' | ').replace(/\n/g, '')).join('\n')
-
-      if (!program.color) { items = stripAnsi(items) }
-
-      console.log(items)
+        if (program.dump) {
+            console.log(JSON.stringify(items, null, 4))
+            return
+        }
+        
+        items = items.map(el => [
+            el.fileID + '',
+            el.domain + ': ' + el.relativePath
+        ])
+        
+        items = [['ID', 'Domain/Path'], ['-'], ...items]
+        items = normalizeCols(items, 1).map(el => el.join(' | ').replace(/\n/g, '')).join('\n')
+        
+        if (!program.color) { items = stripAnsi(items) }
+        
+        console.log(items)
     })
     .catch((e) => {
-      console.log('[!] Encountered an Error:', e)
+        console.log('[!] Encountered an Error:', e)
     })
 }

--- a/tools/reports/manifest.js
+++ b/tools/reports/manifest.js
@@ -7,14 +7,18 @@ const path = require('path')
 module.exports.name = 'manifest'
 module.exports.description = 'List all the files contained in the backup (iOS 10+)'
 
-module.exports.func = function (program, base) {
-    if (!program.backup) {
-        console.log('use -b or --backup <id> to specify backup.')
-        process.exit(1)
-    }
-    
-    // Grab the backup
-    var backup = iPhoneBackup.fromID(program.backup, base)
+// Specify this reporter requires a backup. 
+// The second parameter to func() is now a backup instead of the path to one.
+module.exports.requiresBackup = true
+
+// Specify this reporter supports the promises API for allowing chaining of reports.
+module.exports.usesPromises = true
+
+// Specify this only works for iOS 10+
+module.exports.supportedVersions = '>=10.0'
+
+module.exports.func = function (program, backup, resolve, reject) {
+
     backup.getFileManifest()
     .then((items) => {
       if (program.dump) {
@@ -61,19 +65,19 @@ module.exports.func = function (program, base) {
             console.log(chalk.red('fail'), item.relativePath, e.toString())
           }
         }
+
+        resolve(result)
       } else {
-        // Otherwise, output the table of items.
-        items = items.map(el => [
-          el.fileID + '',
-          el.domain + ': ' + el.relativePath
-        ])
 
-        items = [['ID', 'Domain/Path'], ['-'], ...items]
-        items = normalizeCols(items, 1).map(el => el.join(' | ').replace(/\n/g, '')).join('\n')
+        var result = program.formatter.format(items, {
+          program: program,
+          columns: {
+            'ID': el => el.fileID,
+            'Domain/Path': el => el.domain + ': ' + el.relativePath
+          }
+        })
 
-        if (!program.color) { items = stripAnsi(items) }
-
-        console.log(items)
+        resolve(result)
       }
     })
     .catch((e) => {

--- a/tools/reports/messages.js
+++ b/tools/reports/messages.js
@@ -5,23 +5,30 @@ const normalizeCols = require('../util/normalize.js')
 
 module.exports.name = 'messages'
 module.exports.description = 'List all SMS and iMessage messages in a conversation'
+
+// Specify this reporter requires a backup. 
+// The second parameter to func() is now a backup instead of the path to one.
 module.exports.requiresBackup = true
 
-module.exports.func = function (program, base) {
+// Specify this reporter supports the promises API for allowing chaining of reports.
+module.exports.usesPromises = true
+
+// Should this report be skipped in automated reports?
+// This is used when the 'all' report type is specified, and all possible reports are generated.
+// with this set to true, the report WILL NOT run when report type = 'all'
+module.exports.requiresInteractivity = true
+
+module.exports.func = function (program, backup, resolve, reject) {
   if (!program.id) {
     console.log('use -i or --id <id> to specify conversation ID.')
     process.exit(1)
   }
 
-  // Grab the backup
-  var backup = iPhoneBackup.fromID(program.backup, base)
-
   backup.getMessages(program.id)
     .then((items) => {
-      console.log(items.length)
-
-      program.formatter.format(items, {
-        color: program.color,
+  
+      var result = program.formatter.format(items, {
+        program: program,
         columns: {
           'ID' : el => el.ROWID,
           'Date': el => el.XFORMATTEDDATESTRING,
@@ -29,8 +36,8 @@ module.exports.func = function (program, base) {
           'Text': el => (el.text || '').trim()
         }
       })
+
+      resolve(result)
     })
-    .catch((e) => {
-      console.log('[!] Encountered an Error:', e)
-    })
+    .catch(reject)
 }

--- a/tools/reports/notes.js
+++ b/tools/reports/notes.js
@@ -4,25 +4,32 @@ const normalizeCols = require('../util/normalize.js')
 
 module.exports.name = 'notes'
 module.exports.description = 'List all iOS notes'
+
+// Specify this only works for iOS 10+
+module.exports.supportedVersions = '>=9.0'
+
+// Specify this reporter requires a backup. 
+// The second parameter to func() is now a backup instead of the path to one.
 module.exports.requiresBackup = true
 
-module.exports.functions = {
-  '>=9.0' : function (program, backup) {
-    backup.getNotes(program.dump)
-      .then((items) => {
-        // Format the output
-        program.formatter.format(items, {
-          color: program.color,
-          columns: {
-            'Modified': el => (el.XFORMATTEDDATESTRING || el.XFORMATTEDDATESTRING1) + '',
-            'ID': el => el.Z_PK,
-            'Title2': el => (el.ZTITLE2 + '').trim().substring(0, 128),
-            'Title1': el => (el.ZTITLE1 + '').trim() || ''
-          }
-        })
+// Specify this reporter supports the promises API for allowing chaining of reports.
+module.exports.usesPromises = true
+
+module.exports.func = function (program, backup, resolve, reject) {
+  backup.getNotes(program.dump)
+    .then((items) => {
+      // Format the output
+      var result = program.formatter.format(items, {
+        program: program,
+        columns: {
+          'Modified': el => (el.XFORMATTEDDATESTRING || el.XFORMATTEDDATESTRING1) + '',
+          'ID': el => el.Z_PK,
+          'Title2': el => (el.ZTITLE2 + '').trim().substring(0, 128),
+          'Title1': el => (el.ZTITLE1 + '').trim() || ''
+        }
       })
-      .catch((e) => {
-        console.log('[!] Encountered an Error:', e)
-      })
-  }
+
+      resolve(result)
+    })
+    .catch(reject)
 }

--- a/tools/reports/notes.js
+++ b/tools/reports/notes.js
@@ -4,38 +4,25 @@ const normalizeCols = require('../util/normalize.js')
 
 module.exports.name = 'notes'
 module.exports.description = 'List all iOS notes'
+module.exports.requiresBackup = true
 
-module.exports.func = function (program, base) {
-  if (!program.backup) {
-    console.log('use -b or --backup <id> to specify backup.')
-    process.exit(1)
+module.exports.functions = {
+  '>=9.0' : function (program, backup) {
+    backup.getNotes(program.dump)
+      .then((items) => {
+        // Format the output
+        program.formatter.format(items, {
+          color: program.color,
+          columns: {
+            'Modified': el => (el.XFORMATTEDDATESTRING || el.XFORMATTEDDATESTRING1) + '',
+            'ID': el => el.Z_PK,
+            'Title2': el => (el.ZTITLE2 + '').trim().substring(0, 128),
+            'Title1': el => (el.ZTITLE1 + '').trim() || ''
+          }
+        })
+      })
+      .catch((e) => {
+        console.log('[!] Encountered an Error:', e)
+      })
   }
-
-// Grab the backup
-  var backup = iPhoneBackup.fromID(program.backup, base)
-  backup.getNotes(program.dump)
-    .then((items) => {
-        // Dump if needed
-      if (program.dump) {
-        console.log(JSON.stringify(items, null, 4))
-        return
-      }
-
-        // Otherwise, format table
-      items = items.map(el => [
-        (el.XFORMATTEDDATESTRING || el.XFORMATTEDDATESTRING1) + '',
-            (el.Z_PK + ''),
-        (el.ZTITLE2 + '').trim().substring(0, 128),
-        (el.ZTITLE1 + '').trim() || ''
-      ])
-      items = [['Modified', 'ID', 'Title2', 'Title1'], ['-', '-', '-', '-'], ...items]
-      items = normalizeCols(items, 3).map(el => el.join(' | ')).join('\n')
-
-      if (!program.color) { items = stripAnsi(items) }
-
-      console.log(items)
-    })
-    .catch((e) => {
-      console.log('[!] Encountered an Error:', e)
-    })
 }

--- a/tools/reports/oldnotes.js
+++ b/tools/reports/oldnotes.js
@@ -15,25 +15,15 @@ module.exports.func = function (program, base) {
   var backup = iPhoneBackup.fromID(program.backup, base)
   backup.getOldNotes(program.dump)
     .then((items) => {
-      // Dump if needed
-      if (program.dump) {
-        console.log(JSON.stringify(items, null, 4))
-        return
-      }
 
-      // Otherwise, format table
-      items = items.map(el => [el.XFORMATTEDDATESTRING + '', (el.Z_PK + ''), (el.ZTITLE + '').substring(0, 128)])
-      items = [
-        ['Modified', 'ID', 'Title'],
-        ['-', '-', '-'], ...items
-      ]
-      items = normalizeCols(items).map(el => el.join(' | ')).join('\n')
-
-      if (!program.color) {
-        items = stripAnsi(items)
-      }
-
-      console.log(items)
+      program.formatter.format(items, {
+        color: program.color,
+        columns: {
+          'Modified': el => el.XFORMATTEDDATESTRING,
+          'ID': el => el.Z_PK,
+          'Title': el => (el.ZTITLE + '').substring(0, 128)
+        }
+      })
     })
     .catch((e) => {
       console.log('[!] Encountered an Error:', e)

--- a/tools/reports/oldnotes.js
+++ b/tools/reports/oldnotes.js
@@ -5,27 +5,28 @@ const normalizeCols = require('../util/normalize.js')
 module.exports.name = 'oldnotes'
 module.exports.description = 'List all iOS notes (from older unused database)'
 
-module.exports.func = function (program, base) {
-  if (!program.backup) {
-    console.log('use -b or --backup <id> to specify backup.')
-    process.exit(1)
-  }
+// Specify this reporter requires a backup. 
+// The second parameter to func() is now a backup instead of the path to one.
+module.exports.requiresBackup = true
 
-  // Grab the backup
-  var backup = iPhoneBackup.fromID(program.backup, base)
+// Specify this reporter supports the promises API for allowing chaining of reports.
+module.exports.usesPromises = true
+
+module.exports.func = function (program, backup, resolve, reject) {
+
   backup.getOldNotes(program.dump)
     .then((items) => {
 
-      program.formatter.format(items, {
-        color: program.color,
+      var result = program.formatter.format(items, {
+        program: program,
         columns: {
           'Modified': el => el.XFORMATTEDDATESTRING,
           'ID': el => el.Z_PK,
           'Title': el => (el.ZTITLE + '').substring(0, 128)
         }
       })
+
+      resolve(result)
     })
-    .catch((e) => {
-      console.log('[!] Encountered an Error:', e)
-    })
+    .catch(reject)
 }

--- a/tools/reports/photolocations.js
+++ b/tools/reports/photolocations.js
@@ -5,16 +5,19 @@ module.exports.description = 'List all geolocation information for iOS photos (i
 // The second parameter to func() is now a backup instead of the path to one.
 module.exports.requiresBackup = true
 
+// Specify this reporter supports the promises API for allowing chaining of reports.
+module.exports.usesPromises = true
+
 // Specify this only works for iOS 10+
 module.exports.supportedVersions = '>=10.0'
 
 // Reporting function
-module.exports.func = function (program, backup) {
+module.exports.func = function (program, backup, resolve, reject) {
   backup.getPhotoLocationHistory()
     .then((history) => {
       // Format the output according to the configured formatter.
-      program.formatter.format(history, {
-        color: program.color,
+      var output = program.formatter.format(history, {
+        program: program,
         columns: {
           'Time': el => el.XFORMATTEDDATESTRING,
           'Latitude': el => el.ZLATITUDE,
@@ -22,8 +25,8 @@ module.exports.func = function (program, backup) {
           'File': el => el.ZFILENAME,
         }
       })
+
+      resolve(output)
     })
-    .catch((e) => {
-      console.log('[!] Encountered an Error:', e)
-    })
+    .catch(reject)
 }

--- a/tools/reports/photolocations.js
+++ b/tools/reports/photolocations.js
@@ -1,38 +1,27 @@
-const stripAnsi = require('strip-ansi')
-const iPhoneBackup = require('../util/iphone_backup.js').iPhoneBackup
-const normalizeCols = require('../util/normalize.js')
-
 module.exports.name = 'photolocations'
 module.exports.description = 'List all geolocation information for iOS photos (iOS 10+)'
 
-module.exports.func = function (program, base) {
-  if (!program.backup) {
-    console.log('use -b or --backup <id> to specify backup.')
-    process.exit(1)
-  }
+// Specify this reporter requires a backup. 
+// The second parameter to func() is now a backup instead of the path to one.
+module.exports.requiresBackup = true
 
-// Grab the backup
-  var backup = iPhoneBackup.fromID(program.backup, base)
-  backup.getPhotoLocationHistory(program.dump)
+// Specify this only works for iOS 10+
+module.exports.supportedVersions = '>=10.0'
+
+// Reporting function
+module.exports.func = function (program, backup) {
+  backup.getPhotoLocationHistory()
     .then((history) => {
-      if (program.dump) {
-        console.log(JSON.stringify(history, null, 4))
-        return
-      }
-
-      var items = history.map(el => [
-        el.XFORMATTEDDATESTRING + '' || '',
-        el.ZLATITUDE + '' || '',
-        el.ZLONGITUDE + '' || '',
-        el.ZFILENAME + '' || ''
-      ])
-
-      items = [['Time', 'Latitude', 'Longitude', 'Photo Name'], ['-', '-', '-'], ...items]
-      items = normalizeCols(items).map(el => el.join(' | ').replace(/\n/g, '')).join('\n')
-
-      if (!program.color) { items = stripAnsi(items) }
-
-      console.log(items)
+      // Format the output according to the configured formatter.
+      program.formatter.format(history, {
+        color: program.color,
+        columns: {
+          'Time': el => el.XFORMATTEDDATESTRING,
+          'Latitude': el => el.ZLATITUDE,
+          'Longitude': el => el.ZLONGITUDE,
+          'File': el => el.ZFILENAME,
+        }
+      })
     })
     .catch((e) => {
       console.log('[!] Encountered an Error:', e)

--- a/tools/reports/voicemail.js
+++ b/tools/reports/voicemail.js
@@ -5,16 +5,19 @@ module.exports.description = 'List all or extract voicemails on device'
 // The second parameter to func() is now a backup instead of the path to one.
 module.exports.requiresBackup = true
 
+// Specify this reporter supports the promises API for allowing chaining of reports.
+module.exports.usesPromises = true
+
 // Specify this only works for iOS 10+
 module.exports.supportedVersions = '>=9.0'
 
-module.exports.func = function (program, backup) {
+module.exports.func = function (program, backup, resolve, reject) {
 
   backup.getVoicemailsList()
     .then((items) => {
 
-      program.formatter.format(items, {
-        color: program.color,
+      var result = program.formatter.format(items, {
+        program: program,
         columns: {
           'ID': el => el.ROWID,
           'Date': el => el.XFORMATTEDDATESTRING,
@@ -27,8 +30,8 @@ module.exports.func = function (program, backup) {
           'Flags': el => el.flags
         }
       })
+
+      resolve(result)
     })
-    .catch((e) => {
-      console.log('[!] Encountered an Error:', e)
-    })
+    .catch(reject)
 }

--- a/tools/reports/voicemail.js
+++ b/tools/reports/voicemail.js
@@ -1,42 +1,32 @@
-const stripAnsi = require('strip-ansi')
-const iPhoneBackup = require('../util/iphone_backup.js').iPhoneBackup
-const normalizeCols = require('../util/normalize.js')
-
 module.exports.name = 'voicemail'
 module.exports.description = 'List all or extract voicemails on device'
 
-module.exports.func = function (program, base) {
-  if (!program.backup) {
-    console.log('use -b or --backup <id> to specify backup.')
-    process.exit(1)
-  }
+// Specify this reporter requires a backup. 
+// The second parameter to func() is now a backup instead of the path to one.
+module.exports.requiresBackup = true
 
-// Grab the backup
-  var backup = iPhoneBackup.fromID(program.backup, base)
+// Specify this only works for iOS 10+
+module.exports.supportedVersions = '>=9.0'
+
+module.exports.func = function (program, backup) {
+
   backup.getVoicemailsList()
     .then((items) => {
-      if (program.dump) {
-        console.log(JSON.stringify(items, null, 4))
-        return
-      }
 
-      items = items.map(el => [
-        el.ROWID + '',
-        el.XFORMATTEDDATESTRING,
-        el.sender + '',
-        el.token + '',
-        el.duration + '',
-        el.expiration + '',
-        el.trashed_date + '',
-        el.flags + ''
-      ])
-
-      items = [['ID', 'Date', 'Sender', 'Token', 'Duration', 'Expiration', 'Trashed', 'Flags'], ['-', '-', '-', '-', '-', '-', '-', '-'], ...items]
-      items = normalizeCols(items).map(el => el.join(' | ').replace(/\n/g, '')).join('\n')
-
-      if (!program.color) { items = stripAnsi(items) }
-
-      console.log(items)
+      program.formatter.format(items, {
+        color: program.color,
+        columns: {
+          'ID': el => el.ROWID,
+          'Date': el => el.XFORMATTEDDATESTRING,
+          'Sender': el => el.sender,
+          'Token': el => el.token,
+          'Duration': el => el.duration,
+          'Expiration': el => el.expiration,
+          'Duration': el => el.duration,
+          'Trashed': el => el.trashed_date,
+          'Flags': el => el.flags
+        }
+      })
     })
     .catch((e) => {
       console.log('[!] Encountered an Error:', e)

--- a/tools/reports/webhistory.js
+++ b/tools/reports/webhistory.js
@@ -10,24 +10,27 @@ module.exports.description = 'List all web history'
 // The second parameter to func() is now a backup instead of the path to one.
 module.exports.requiresBackup = true
 
+// Specify this reporter supports the promises API for allowing chaining of reports.
+module.exports.usesPromises = true
+
 // Specify this only works for iOS 6+
 module.exports.supportedVersions = '>=9.0'
 
-module.exports.func = function (program, backup) {
+module.exports.func = function (program, backup, resolve, reject) {
 
   backup.getWebHistory(program.dump)
     .then((history) => {
       
-      program.formatter.format(history, {
-        color: program.color,
+      var result = program.formatter.format(history, {
+        program: program,
         columns: {
           'Time': el => el.XFORMATTEDDATESTRING,
           'URL': el => new URL(el.url || '').origin || '',
           'Title': el => (el.title || '').substring(0, 64)
         }
       })
+
+      resolve(result)
     })
-    .catch((e) => {
-      console.log('[!] Encountered an Error:', e)
-    })
+    .catch(reject)
 }

--- a/tools/reports/wifi.js
+++ b/tools/reports/wifi.js
@@ -15,27 +15,19 @@ module.exports.func = function (program, base) {
   var backup = iPhoneBackup.fromID(program.backup, base)
   backup.getWifiList()
     .then((items) => {
-      if (program.dump) {
-        console.log(JSON.stringify(items, null, 4))
-        return
-      }
 
-      items = items['List of known networks'].map(el => [
-        el.lastJoined + '' || '',
-        el.lastAutoJoined + '' || '',
-        el.SSID_STR + '',
-        el.BSSID + '',
-        el.SecurityMode || '',
-        el.HIDDEN_NETWORK + '',
-        el.enabled + ''
-      ]).sort((a, b) => new Date(a[0]).getTime() - new Date(b[0]).getTime())
-
-      items = [['Last Joined', 'Last AutoJoined', 'SSID', 'BSSID', 'Security', 'Hidden', 'Enabled'], ['-', '-', '-', '-', '-', '-'], ...items]
-      items = normalizeCols(items).map(el => el.join(' | ').replace(/\n/g, '')).join('\n')
-
-      if (!program.color) { items = stripAnsi(items) }
-
-      console.log(items)
+      program.formatter.format(items['List of known networks'], {
+        color: program.color,
+        columns: {
+          'Last Joined': el => el.lastJoined,
+          'Last AutoJoined': el => el.lastAutoJoined,
+          'SSID': el => el.SSID_STR,
+          'BSSID': el => el.BSSID,
+          'Security': el => el.SecurityMode || '',
+          'Hidden': el => el.HIDDEN_NETWORK || '',
+          'Enabled': el => el.enabled
+        }
+      })
     })
     .catch((e) => {
       console.log('[!] Encountered an Error:', e)

--- a/tools/reports/wifi.js
+++ b/tools/reports/wifi.js
@@ -5,19 +5,20 @@ const normalizeCols = require('../util/normalize.js')
 module.exports.name = 'wifi'
 module.exports.description = 'List associated wifi networks and their usage information'
 
-module.exports.func = function (program, base) {
-  if (!program.backup) {
-    console.log('use -b or --backup <id> to specify backup.')
-    process.exit(1)
-  }
+// Specify this reporter requires a backup. 
+// The second parameter to func() is now a backup instead of the path to one.
+module.exports.requiresBackup = true
 
-// Grab the backup
-  var backup = iPhoneBackup.fromID(program.backup, base)
+// Specify this reporter supports the promises API for allowing chaining of reports.
+module.exports.usesPromises = true
+
+module.exports.func = function (program, backup, resolve, reject) {
+
   backup.getWifiList()
     .then((items) => {
 
-      program.formatter.format(items['List of known networks'], {
-        color: program.color,
+      var result = program.formatter.format(items['List of known networks'], {
+        program: program,
         columns: {
           'Last Joined': el => el.lastJoined,
           'Last AutoJoined': el => el.lastAutoJoined,
@@ -28,8 +29,8 @@ module.exports.func = function (program, base) {
           'Enabled': el => el.enabled
         }
       })
+
+      resolve(result)
     })
-    .catch((e) => {
-      console.log('[!] Encountered an Error:', e)
-    })
+    .catch(reject)
 }

--- a/tools/util/iphone_backup.js
+++ b/tools/util/iphone_backup.js
@@ -44,22 +44,29 @@ class iPhoneBackup {
 
     // Parse manifest bplist files
     try {
+      if (global.verbose) console.log('parsing status', base)
       var status = bplist.parseBuffer(fs.readFileSync(path.join(base, 'Status.plist')))[0]
     } catch (e) {
       console.log('Cannot open Status.plist', e)
     }
     try {
+      if (global.verbose) console.log('parsing manifest', base)
       var manifest = bplist.parseBuffer(fs.readFileSync(path.join(base, 'Manifest.plist')))[0]
     } catch (e) {
       console.log('Cannot open Manifest.plist', e)
     }
     try {
+      if (global.verbose) console.log('parsing status', base)
       var info = plist.parse(fs.readFileSync(path.join(base, 'Info.plist'), 'utf8'))
     } catch (e) {
       console.log('Cannot open Info.plist', e)
     }
 
     return new iPhoneBackup(id, status, info, manifest, base)
+  }
+
+  get iOSVersion () {
+    return this.manifest.Lockdown.ProductVersion
   }
 
   getFileName (fileID, isAbsoulte) {
@@ -85,6 +92,17 @@ class iPhoneBackup {
       // v3 has folders
       return new sqlite3.Database(path.join(this.base, fileID.substr(0, 2), fileID), sqlite3.OPEN_READONLY)
     }
+  }
+
+  queryDatabase (databaseID, sql) {
+    return new Promise((resolve, reject) => {
+      var messagedb = this.getDatabase(databaseID)
+      messagedb.all(sql, async function (err, rows) {
+        if (err) reject(err)
+
+        resolve(rows)
+      })
+    })
   }
 
   getName (messageDest) {

--- a/tools/util/iphone_backup.js
+++ b/tools/util/iphone_backup.js
@@ -143,7 +143,7 @@ class iPhoneBackup {
     })
   }
 
-  getMessagesiOS9 (chatId, dumpAll) {
+  getMessagesiOS9 (chatId) {
     var backup = this
     return new Promise((resolve, reject) => {
       var messagedb = this.getDatabase(databases.SMS)
@@ -163,7 +163,6 @@ class iPhoneBackup {
        if (err) return reject(err)
 
        chats = chats || []
-       if (dumpAll) console.log(JSON.stringify(chats, null, 4))
 
         // Compute the user's name
        for (var i in chats) {
@@ -184,7 +183,7 @@ class iPhoneBackup {
     })
   }
 
-  getMessagesiOS10iOS11 (chatId, dumpAll) {
+  getMessagesiOS10iOS11 (chatId) {
     var backup = this
     return new Promise((resolve, reject) => {
       var messagedb = this.getDatabase(databases.SMS)
@@ -204,7 +203,6 @@ class iPhoneBackup {
        if (err) return reject(err)
 
        chats = chats || []
-       if (dumpAll) console.log(JSON.stringify(chats, null, 4))
 
         // Compute the user's name
        for (var i in chats) {
@@ -225,15 +223,15 @@ class iPhoneBackup {
     })
   }
 
-  getMessages (chatId, dumpAll) {
+  getMessages (chatId) {
     if (parseInt(this.manifest.Lockdown.BuildVersion) <= 13) {
-      return this.getMessagesiOS9(chatId, dumpAll)
+      return this.getMessagesiOS9(chatId)
     } else {
-      return this.getMessagesiOS10iOS11(chatId, dumpAll)
+      return this.getMessagesiOS10iOS11(chatId)
     }
   }
 
-  getConversationsiOS9 (dumpAll) {
+  getConversationsiOS9 () {
     var backup = this
     return new Promise((resolve, reject) => {
       var messagedb = this.getDatabase(databases.SMS)
@@ -280,32 +278,28 @@ class iPhoneBackup {
           return (a.date.getTime() || 0) - (b.date.getTime() || 0)
         })
 
-        if (dumpAll) console.log(JSON.stringify(rows, null, 4))
-
         resolve(rows)
       })
     })
   }
 
-  getConversationsiOS10iOS11 (dumpAll) {
+  getConversationsiOS10iOS11 () {
     return new Promise((resolve, reject) => {
       var messagedb = this.getDatabase(databases.SMS)
       messagedb.all(`SELECT *, datetime(last_read_message_timestamp / 1000000000 + 978307200, 'unixepoch') AS XFORMATTEDDATESTRING FROM chat ORDER BY last_read_message_timestamp ASC`, async function (err, rows) {
         if (err) return reject(err)
         rows = rows || []
 
-        if (dumpAll) console.log(JSON.stringify(rows, null, 4))
-
         resolve(rows)
       })
     })
   }
 
-  getConversations (dumpAll) {
+  getConversations () {
     if (parseInt(this.manifest.Lockdown.BuildVersion) <= 14) {
-      return this.getConversationsiOS9(dumpAll)
+      return this.getConversationsiOS9()
     } else {
-      return this.getConversationsiOS10iOS11(dumpAll)
+      return this.getConversationsiOS10iOS11()
     }
   }
 

--- a/tools/util/normalize.js
+++ b/tools/util/normalize.js
@@ -1,35 +1,34 @@
 const stripAnsi = require('strip-ansi')
 
-module.exports = function normalizeOutput(rows, max) {
-    function padEnd(string, maxLength, fillString) {
-        while(stripAnsi(string).length < maxLength) {
-            string = string + fillString;
-        }    
-    
-        return string   
+module.exports = function normalizeOutput (rows, max) {
+  function padEnd (string, maxLength, fillString) {
+    while (stripAnsi(string).length < maxLength) {
+      string = string + fillString
     }
 
-    var widths = []
-    max = max || rows[0].length
+    return string
+  }
 
-    for(var i = 0; i < rows.length; i++) {
-        for(var j = 0; j < rows[i].length && j < max; j++) {
-            if(!widths[j] || widths[j] < stripAnsi(rows[i][j]).length) {
-                widths[j] = stripAnsi(rows[i][j]).length
-            }
-        }
+  var widths = []
+  max = max || rows[0].length
+
+  for (var i = 0; i < rows.length; i++) {
+    for (var j = 0; j < rows[i].length && j < max; j++) {
+      if (!widths[j] || widths[j] < stripAnsi(rows[i][j]).length) {
+        widths[j] = stripAnsi(rows[i][j]).length
+      }
     }
+  }
 
-    for(var i = 0; i < rows.length; i++) {
-        for(var j = 0; j < rows[i].length && j < max; j++) {
-            if(rows[i][j] == '-') {
-                rows[i][j] = padEnd(rows[i][j], widths[j], '-')
-            } else {
-                rows[i][j] = padEnd(rows[i][j], widths[j], ' ')
-            }
-        }
+  for (var i = 0; i < rows.length; i++) {
+    for (var j = 0; j < rows[i].length && j < max; j++) {
+      if (rows[i][j] == '-') {
+        rows[i][j] = padEnd(rows[i][j], widths[j], '-')
+      } else {
+        rows[i][j] = padEnd(rows[i][j], widths[j], ' ')
+      }
     }
+  }
 
-    return rows
-    
+  return rows
 }

--- a/tools/util/version_compare.js
+++ b/tools/util/version_compare.js
@@ -1,0 +1,74 @@
+// Add zeros to an array until it reaches a specific length.
+function zeroPad (array, length) {
+  for (var i = array.length; i < length; i++) {
+    array[i] = 0
+  }
+
+  return array
+}
+
+function aLessB (a, b) {
+  var maxLength = a.length > b.length ? a.length : b.length
+
+  a = zeroPad(a.map(el => el === undefined ? 0 : parseInt(el)), maxLength)
+  b = zeroPad(b.map(el => el === undefined ? 0 : parseInt(el)), maxLength)
+
+  // Check if any of the declared items in a are less than their component in B.
+  for (let i = 0; i < a.length; i++) {
+    // If this component is less, the entire thing must be less
+    if (a[i] < b[i]) {
+      return true
+    }
+
+    // If this item is greater, the entire thing is greater.
+    if (a[i] > b[i]) {
+      return false
+    }
+  }
+
+  return true
+}
+
+// Check if two arrays are equal.
+function aEqualB (a, b) {
+  if (a.length !== b.length) return false
+
+  for (var i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) {
+      return false
+    }
+  }
+
+  return true
+}
+
+// Comparison types
+const comparisonFuncs = {
+  '>=': (a, b) => { return !aLessB(a, b) || aEqualB(a, b) },
+  '>': (a, b) => { return !aLessB(a, b) },
+  '<=': (a, b) => { return aLessB(a, b) || aEqualB(a, b) },
+  '<': (a, b) => { return aLessB(a, b) },
+  '=': (a, b) => { return aEqualB(a, b) }
+}
+
+function comparison (backup, declared) {
+  var backupComponents = /(>=|>|<|<=|=|~)?(?: +)?(\d+)(?:\.(\d+))?(?:\.(\d+))?/g.exec(backup)
+  var declaredComponents = /(>=|>|<|<=|=|~)?(?: +)?(\d+)(?:\.(\d+))?(?:\.(\d+))?/g.exec(declared)
+
+  const comparison = declaredComponents[1]
+
+  return comparisonFuncs[comparison](backupComponents.slice(2, 5), declaredComponents.slice(2, 5))
+}
+
+// Check if a version satisfies a declared version constraint
+module.exports.versionCheck = function (backup, declared) {
+  var declaredItems = declared.split(',').map(el => el.trim())
+
+  for (var i = 0; i < declaredItems.length; i++) {
+    if (!comparison(backup, declaredItems[i])) {
+      return false
+    }
+  }
+
+  return true
+}


### PR DESCRIPTION
- [x] Make formatting reports more modular (backwards-compatible)
- [x] Reports can specify compatible iOS Versions, or supply multiple versions of the formatter for different iOS version ranges.
    - See `tools/reports/_example.js` for an example reporter module and how to specify supported iOS Versions
- [x] Remove old-style command flags
   - `-c`, `-m`, `--dump`
   - `-f` (for filtering), is replaced by `-f` for formatting reports.
- [x] Formatted JSON output
- [x] Promise based API for developing reports that return data asynchronously.
   - If an output file is specified, the returned output from the promise is written to a file.
   - Otherwise, it is simply printed to STDOUT.
- [x] Multiple reporting output
    - Output multiple tables to STDOUT
    - Unified JSON output
    - File output based on report names.

You can specify report types using the `--formatter <type>` or `-f <type>` flags. Currently, the following reporters are implemented / planned:
- `csv` csv output for viewing in excel
- `raw-csv` full-data csv output for viewing in excel
- `json` formatted json output
- `raw-json` full-data output
- `table` formatted table for easy viewing in the terminal

You can specify an output file/directory to write to disk using the `-o <path>` or `--output <path>` flags.

Additionally, for `json` and `raw-json`, the option to join the reports together is given using the flag `--join-reports`

Fixes #8 

## Breaking Changes
Removed: `-f` shortcut for filtering. using `--filter` is now required. The `-f` flag still exists but is for selecting an output formatter, since `--filter` is used rarely.
Removed `-c` shortcut for listing conversations in favor of using `-r conversations`
Removed `-m` shortcut for listing messages in favor of using `-r messages`
Removed `--dump` in favor of using  the new raw json formatter: `-f raw`