### PR TITLE
Fix incorrect object access in Viber messages report

### DIFF
--- a/tools/reports/thirdparty/viber/messages.js
+++ b/tools/reports/thirdparty/viber/messages.js
@@ -19,7 +19,7 @@ module.exports = {
   // Fields for apps report
   output: {
           'PK': el => el.Z_PK,
-          'Date': el => ZDATE_STRING,
+          'Date': el => el.ZDATE_STRING,
           'Name': el => el.ZDISPLAYFULLNAME,
           'Text': el => el.ZTEXT,
           'State': el => el.ZSTATE


### PR DESCRIPTION
Fixed missing object specifier when accessing `ZDATE_STRING` property