### PR TITLE
Windows file path support

### DIFF
--- a/tools/index.js
+++ b/tools/index.js
@@ -4,10 +4,18 @@ const report = require('./reports')
 const matcher = require('./util/matcher')
 const Group = report.Group
 const Backup = require('./backup')
-const os = require('os')
 
 // Backup source directory
-var backupDirectory = path.join(os.homedir(), '/Library/Application Support/MobileSync/Backup/')
+osType = process.platform
+if (osType === "win32") {
+  console.log('[i] Detected OS: Windows')
+  var backupDirectory = path.join(require('os').homedir(), '\\Apple\\MobileSync\\Backup')
+} else if (osType === "darwin") {
+  console.log('[i] Detected OS: MacOS')
+  var backupDirectory = path.join(process.env.HOME, '/Library/Application Support/MobileSync/Backup/')
+} else {
+  console.log('[i] Detected OS:', osType, 'may not be properly supported')
+}
 
 // Object containing all report modules
 var moduleCache = report.types

--- a/tools/index.js
+++ b/tools/index.js
@@ -4,15 +4,14 @@ const report = require('./reports')
 const matcher = require('./util/matcher')
 const Group = report.Group
 const Backup = require('./backup')
+const os = require('os')
 
 // Backup source directory
 osType = process.platform
 if (osType === "win32") {
-  console.log('[i] Detected OS: Windows')
   var backupDirectory = path.join(require('os').homedir(), '\\Apple\\MobileSync\\Backup')
 } else if (osType === "darwin") {
-  console.log('[i] Detected OS: MacOS')
-  var backupDirectory = path.join(process.env.HOME, '/Library/Application Support/MobileSync/Backup/')
+  var backupDirectory = path.join(os.homedir(), '/Library/Application Support/MobileSync/Backup/')
 } else {
   console.log('[i] Detected OS:', osType, 'may not be properly supported')
 }

--- a/tools/index.js
+++ b/tools/index.js
@@ -7,13 +7,11 @@ const Backup = require('./backup')
 const os = require('os')
 
 // Backup source directory
+var backupDirectory = path.join(os.homedir(), '/Library/Application Support/MobileSync/Backup/')
+
 osType = process.platform
 if (osType === "win32") {
   var backupDirectory = path.join(require('os').homedir(), '\\Apple\\MobileSync\\Backup')
-} else if (osType === "darwin") {
-  var backupDirectory = path.join(os.homedir(), '/Library/Application Support/MobileSync/Backup/')
-} else {
-  console.log('[i] Detected OS:', osType, 'may not be properly supported')
 }
 
 // Object containing all report modules


### PR DESCRIPTION
### Adding native Windows path support without the need for --dir attribute 

Added a simple process.platform check at the start of index.js. This will use a Windows based file path which doesn't require the user to enter the --dir attribute. I have tested this from my Windows system and it managed to pull all images out of my iPhone backup successfully and without any hiccups!