### PR TITLE
Windows Directory Support

### DIFF
--- a/tools/index.js
+++ b/tools/index.js
@@ -6,12 +6,14 @@ const Group = report.Group
 const Backup = require('./backup')
 const os = require('os')
 
-// Backup source directory
+// Backup source directory (macos)
 var backupDirectory = path.join(os.homedir(), '/Library/Application Support/MobileSync/Backup/')
 
-osType = process.platform
+const osType = process.platform
+
+// Set windows backup directory
 if (osType === "win32") {
-  var backupDirectory = path.join(require('os').homedir(), '\\Apple\\MobileSync\\Backup')
+  backupDirectory = path.join(require('os').homedir(), '\\Apple\\MobileSync\\Backup')
 }
 
 // Object containing all report modules

--- a/tools/index.js
+++ b/tools/index.js
@@ -9,6 +9,11 @@ const os = require('os')
 // Backup source directory
 var backupDirectory = path.join(os.homedir(), '/Library/Application Support/MobileSync/Backup/')
 
+osType = process.platform
+if (osType === "win32") {
+  var backupDirectory = path.join(require('os').homedir(), '\\Apple\\MobileSync\\Backup')
+}
+
 // Object containing all report modules
 var moduleCache = report.types
 


### PR DESCRIPTION
supersedes #72 

> *Adding native Windows path support without the need for --dir attribute*
> Added a simple process.platform check at the start of index.js. This will use a Windows based file path which doesn't require the user to enter the --dir attribute. I have tested this from my Windows system and it managed to pull all images out of my iPhone backup successfully and without any hiccups!